### PR TITLE
Remove custom logo and related theme config

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -21,6 +21,8 @@ export default defineUserConfig({
   theme: defaultTheme({
     contributors: false,
     smoothScroll: true,
+    colorMode: 'auto',
+    colorModeSwitch: true,
     locales: {
       '/': {
         selectLanguageName: 'English',

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,36 +1,103 @@
-# Volga
+---
+home: true
+title: Volga
+heroText: Volga
+tagline: Fast, async-first web framework for Rust built on Tokio + Hyper.
+actions:
+  - text: Get Started
+    link: /basics/quick-start.html
+    type: primary
+  - text: View API Docs
+    link: https://docs.rs/volga/latest/volga/
+    type: secondary
+features:
+  - title: Productive by default
+    details: Minimal setup, clear routing, and an ergonomic handler API that keeps your focus on the business logic.
+  - title: Batteries included
+    details: Built-in DI, rate limiting, middleware, tracing, CORS, static files, and more.
+  - title: Type-safe extractors
+    details: Read JSON, query params, headers, cookies, or files with composable, strongly typed extractors.
+footer: MIT Licensed • Built for performance
+---
 
-Fast, easy, and flexible web framework for Rust, built on the [Tokio](https://tokio.rs/) runtime and [hyper](https://hyper.rs/) for building HTTP APIs and microservices.
+## Build APIs that scale with confidence
 
-## Getting Started
-```toml
-[dependencies]
-volga = { version = "..." }
-tokio = { version = "...", features = ["full"] }
-```
+Volga ships with performance-friendly primitives and modern developer ergonomics. From routing to middleware and advanced infrastructure features, you can scale from a single endpoint to a full microservice surface without rewriting core pieces.
+
+## Examples that hook developers fast
+
+### Dependency Injection that feels native
+
 ```rust
-use volga::*;
+use volga::{App, di::Dc, ok, not_found};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Clone, Default)]
+struct InMemoryCache {
+    inner: Arc<Mutex<HashMap<String, String>>>,
+}
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    // Configure the HTTP server
-    let mut app = App::new().bind("localhost:7878");
+    let mut app = App::new();
+    app.add_singleton(InMemoryCache::default());
 
-    // Configure the GET request handler
-    app.map_get("/hello/{name}", async |name: String| {
-        ok!("Hello {}!", name)
+    app.map_get("/user/{id}", |id: String, cache: Dc<InMemoryCache>| async move {
+        let user = cache.inner.lock().unwrap().get(&id);
+        match user {
+            Some(user) => ok!(user),
+            None => not_found!("User not found"),
+        }
     });
-    
-    // Run the server
+
     app.run().await
 }
 ```
 
+### Rate limiting with named policies
 
-<div align="center">
+```rust
+use std::time::Duration;
+use volga::{App, rate_limiting::{by, FixedWindow}};
 
-<a href="https://romanemreis.github.io/volga-docs/basics/quick-start.html" style="display: inline-block; padding: 10px 20px; background-color: #299764; color: #fff; text-decoration: none; border-radius: 25px; font-family: Arial, sans-serif; font-size: 16px; text-align: center;">
-  <span>Learn More</span>
-</a>
+let burst = FixedWindow::new(100, Duration::from_secs(30)).with_name("burst");
 
-</div>
+let mut app = App::new().with_fixed_window(burst);
+
+app.map_get("/upload", upload_handler)
+    .fixed_window(by::ip().using("burst"));
+```
+
+### Extractors that keep handlers clean
+
+```rust
+use volga::{App, Json, ok};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct User {
+    name: String,
+    age: i32,
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_post("/hello", |user: Json<User>| async move {
+        ok!("Hello {}!", user.name)
+    });
+
+    app.run().await
+}
+```
+
+## Explore the docs
+
+- [Quick Start](/basics/quick-start.html)
+- [Dependency Injection](/advanced/di.html)
+- [Rate Limiting](/advanced/rate-limiting.html)
+- [Handling JSON](/data/json-payload.html)

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -1,36 +1,103 @@
-# Волга
+---
+home: true
+title: Волга
+heroText: Волга
+tagline: Быстрый async-first веб-фреймворк для Rust на базе Tokio + Hyper.
+actions:
+  - text: Быстрый старт
+    link: /ru/basics/quick-start.html
+    type: primary
+  - text: API Docs
+    link: https://docs.rs/volga/latest/volga/
+    type: secondary
+features:
+  - title: Продуктивность по умолчанию
+    details: Минимальная настройка, понятный роутинг и удобный API обработчиков для фокуса на логике.
+  - title: Все необходимое внутри
+    details: DI, rate limiting, middleware, tracing, CORS, static files и многое другое из коробки.
+  - title: Типобезопасные экстракторы
+    details: JSON, query params, headers, cookies, файлы — все через композицию типизированных экстракторов.
+footer: MIT Licensed • Сфокусирован на производительности
+---
 
-Гибкий, простой и быстрый веб-фреймворк для Rust на базе [Tokio](https://tokio.rs/) и [hyper](https://hyper.rs/) для разработки HTTP API и микросервисов.
+## Масштабируйте API уверенно
 
-## Начало работы
-```toml
-[dependencies]
-volga = { version = "..." }
-tokio = { version = "...", features = ["full"] }
-```
+Volga предоставляет производительные примитивы и современные практики разработки. От роутинга до middleware и продвинутой инфраструктуры — масштабируйте сервисы без переписывания базовых вещей.
+
+## Примеры, которые цепляют
+
+### DI, которое ощущается нативно
+
 ```rust
-use volga::*;
+use volga::{App, di::Dc, ok, not_found};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Clone, Default)]
+struct InMemoryCache {
+    inner: Arc<Mutex<HashMap<String, String>>>,
+}
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    // Создаем HTTP-сервер
-    let mut app = App::new().bind("localhost:7878");
+    let mut app = App::new();
+    app.add_singleton(InMemoryCache::default());
 
-    // Настраиваем обработчик GET-запросов
-    app.map_get("/hello/{name}", async |name: String| {
-        ok!("Hello {}!", name)
+    app.map_get("/user/{id}", |id: String, cache: Dc<InMemoryCache>| async move {
+        let user = cache.inner.lock().unwrap().get(&id);
+        match user {
+            Some(user) => ok!(user),
+            None => not_found!("User not found"),
+        }
     });
-    
-    // Запускаем сервер
+
     app.run().await
 }
 ```
 
+### Rate limiting с именованными политиками
 
-<div align="center">
+```rust
+use std::time::Duration;
+use volga::{App, rate_limiting::{by, FixedWindow}};
 
-<a href="https://romanemreis.github.io/volga-docs/ru/basics/quick-start.html" style="display: inline-block; padding: 10px 20px; background-color: #299764; color: #fff; text-decoration: none; border-radius: 25px; font-family: Arial, sans-serif; font-size: 16px; text-align: center;">
-  <span>Подробнее</span>
-</a>
+let burst = FixedWindow::new(100, Duration::from_secs(30)).with_name("burst");
 
-</div>
+let mut app = App::new().with_fixed_window(burst);
+
+app.map_get("/upload", upload_handler)
+    .fixed_window(by::ip().using("burst"));
+```
+
+### Экстракторы, которые держат код чистым
+
+```rust
+use volga::{App, Json, ok};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct User {
+    name: String,
+    age: i32,
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_post("/hello", |user: Json<User>| async move {
+        ok!("Hello {}!", user.name)
+    });
+
+    app.run().await
+}
+```
+
+## Изучайте документацию дальше
+
+- [Быстрый старт](/ru/basics/quick-start.html)
+- [Dependency Injection](/ru/advanced/di.html)
+- [Rate Limiting](/ru/advanced/rate-limiting.html)
+- [Handling JSON](/ru/data/json-payload.html)


### PR DESCRIPTION
### Motivation
- Temporarily remove the custom logo and favicons so the site header no longer renders the previously added logo assets.
- Keep the refreshed docs landing pages and examples to provide a clear home layout and developer onboarding while the logo is omitted.

### Description
- Drop the `head` favicon entries and `logo` reference from `docs/.vuepress/config.js` so the theme no longer points to the custom logo.
- Delete the logo SVG assets `docs/.vuepress/public/images/volga-logo.svg` and `docs/.vuepress/public/images/volga-logo-dark.svg` and the dark-mode style `docs/.vuepress/styles/index.scss` that inverted the navbar logo.
- Retain the updated landing pages `docs/README.md` and `docs/ru/README.md` which provide a VuePress home layout and expanded examples.
- Commit the changes to the repository.

### Testing
- Launched the docs dev server with `npm run docs:dev -- --host 0.0.0.0 --port 8080` and confirmed the site served at `http://localhost:8080/volga-docs/` (succeeded).
- Ran a Playwright script that captured a verification screenshot saved as `artifacts/volga-no-logo.png` to confirm the header shows no logo (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d16ad565883329f62075080f0a760)