### PR TITLE
Redesign homepage with enhanced visuals and CodeShowcase component

### DIFF
--- a/docs/.vuepress/client.js
+++ b/docs/.vuepress/client.js
@@ -1,0 +1,8 @@
+import { defineClientConfig } from 'vuepress/client'
+import CodeShowcase from './components/CodeShowcase.vue'
+
+export default defineClientConfig({
+  enhance({ app }) {
+    app.component('CodeShowcase', CodeShowcase)
+  },
+})

--- a/docs/.vuepress/components/CodeShowcase.vue
+++ b/docs/.vuepress/components/CodeShowcase.vue
@@ -1,0 +1,240 @@
+<template>
+  <div class="code-showcase">
+    <div class="code-showcase__tabs">
+      <button
+        v-for="(tab, i) in tabs"
+        :key="i"
+        :class="['code-showcase__tab', { active: activeTab === i }]"
+        @click="activeTab = i"
+      >
+        {{ tab.title }}
+      </button>
+    </div>
+    <div class="code-showcase__card">
+      <div class="code-showcase__window-dots">
+        <span></span><span></span><span></span>
+      </div>
+      <div class="code-showcase__content">
+        <div
+          v-for="(tab, i) in tabs"
+          :key="i"
+          v-show="activeTab === i"
+          class="code-showcase__panel"
+          v-html="highlighted[i]"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  tabs: {
+    type: Array,
+    required: true,
+    // Each tab: { title: string, code: string }
+  }
+})
+
+const activeTab = ref(0)
+
+// Simple Rust syntax highlighter that produces styled spans
+function highlightRust(code) {
+  let html = escapeHtml(code)
+
+  // Comments (// ...)
+  html = html.replace(/(\/\/.*)/g, '<span class="hl-comment">$1</span>')
+
+  // Strings ("...")
+  html = html.replace(/(&quot;(?:[^&]|&(?!quot;))*?&quot;)/g, '<span class="hl-string">$1</span>')
+
+  // Attributes (#[...])
+  html = html.replace(/(#\[[\w:,\s()]*\])/g, '<span class="hl-attr">$1</span>')
+
+  // Macros (word!)
+  html = html.replace(/\b([a-z_]+!)/g, '<span class="hl-macro">$1</span>')
+
+  // Keywords
+  const keywords = ['use','fn','let','mut','async','move','await','struct','match','Some','None','Ok','Err','pub','mod','impl','self','Self','return','if','else','for','in','while','loop','break','continue','where','type','trait','enum','const','static','ref','as','crate','super','extern','unsafe']
+  const kwPattern = new RegExp('\\b(' + keywords.join('|') + ')\\b', 'g')
+  html = html.replace(kwPattern, (m) => {
+    // Don't re-highlight if already inside a span
+    return '<span class="hl-keyword">' + m + '</span>'
+  })
+
+  // Types (PascalCase words)
+  html = html.replace(/\b([A-Z][A-Za-z0-9]*)\b/g, (m) => {
+    return '<span class="hl-type">' + m + '</span>'
+  })
+
+  // Numbers
+  html = html.replace(/\b(\d+(?:\.\d+)?)\b/g, '<span class="hl-number">$1</span>')
+
+  return html
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+const highlighted = computed(() =>
+  props.tabs.map(tab => {
+    const lines = highlightRust(tab.code).split('\n')
+    return '<pre class="hl-pre"><code>' + lines.join('\n') + '</code></pre>'
+  })
+)
+</script>
+
+<style scoped>
+.code-showcase {
+  margin: 1.5rem auto 2.5rem;
+  max-width: 780px;
+}
+
+/* Tabs */
+.code-showcase__tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: none;
+  margin-bottom: -1px;
+  position: relative;
+  z-index: 2;
+  padding-left: 8px;
+}
+
+.code-showcase__tab {
+  padding: 0.6rem 1.25rem;
+  border: none;
+  background: transparent;
+  color: var(--c-text-lighter, #888);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 10px 10px 0 0;
+  transition: all 0.25s ease;
+  font-family: inherit;
+  letter-spacing: 0.01em;
+}
+
+.code-showcase__tab:hover {
+  color: var(--c-text, #333);
+  background: rgba(58, 123, 213, 0.06);
+}
+
+.code-showcase__tab.active {
+  background: #1e1e2e;
+  color: #cdd6f4;
+}
+
+/* Card */
+.code-showcase__card {
+  background: #1e1e2e;
+  border-radius: 16px;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.18),
+    0 2px 8px rgba(0, 0, 0, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+  position: relative;
+}
+
+/* Window dots */
+.code-showcase__window-dots {
+  display: flex;
+  gap: 7px;
+  padding: 14px 18px 0;
+}
+
+.code-showcase__window-dots span {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: block;
+}
+
+.code-showcase__window-dots span:nth-child(1) {
+  background: #f38ba8;
+}
+
+.code-showcase__window-dots span:nth-child(2) {
+  background: #f9e2af;
+}
+
+.code-showcase__window-dots span:nth-child(3) {
+  background: #a6e3a1;
+}
+
+/* Content */
+.code-showcase__content {
+  padding: 0.75rem 0;
+}
+
+.code-showcase__panel :deep(.hl-pre) {
+  margin: 0;
+  padding: 0.75rem 1.5rem 1.25rem;
+  background: transparent;
+  overflow-x: auto;
+  font-size: 0.875rem;
+  line-height: 1.7;
+}
+
+.code-showcase__panel :deep(.hl-pre code) {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace;
+  color: #cdd6f4;
+  background: none;
+  padding: 0;
+}
+
+/* Syntax tokens – Catppuccin Mocha inspired */
+.code-showcase__panel :deep(.hl-keyword) {
+  color: #cba6f7;
+  font-weight: 600;
+}
+
+.code-showcase__panel :deep(.hl-type) {
+  color: #f9e2af;
+}
+
+.code-showcase__panel :deep(.hl-string) {
+  color: #a6e3a1;
+}
+
+.code-showcase__panel :deep(.hl-macro) {
+  color: #89b4fa;
+  font-weight: 600;
+}
+
+.code-showcase__panel :deep(.hl-comment) {
+  color: #6c7086;
+  font-style: italic;
+}
+
+.code-showcase__panel :deep(.hl-number) {
+  color: #fab387;
+}
+
+.code-showcase__panel :deep(.hl-attr) {
+  color: #f38ba8;
+}
+
+/* Subtle glow effect */
+.code-showcase__card::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 16px;
+  padding: 1px;
+  background: linear-gradient(135deg, rgba(58, 123, 213, 0.2), rgba(0, 210, 255, 0.1), transparent 60%);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+</style>

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -1,0 +1,253 @@
+/* ===== Homepage Redesign ===== */
+
+/* ---------- Hero Section ---------- */
+.vp-home {
+  .vp-hero {
+    padding: 3rem 2rem 2rem !important;
+
+    h1 {
+      font-size: 4rem !important;
+      font-weight: 800 !important;
+      letter-spacing: -0.02em;
+      background: linear-gradient(135deg, #3a7bd5 0%, #00d2ff 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      filter: drop-shadow(0 2px 4px rgba(58, 123, 213, 0.15));
+    }
+
+    .vp-hero-description {
+      font-size: 1.25rem !important;
+      color: var(--c-text-lightest);
+      max-width: 600px;
+      margin: 0.5rem auto 0;
+      line-height: 1.7;
+    }
+
+    .vp-hero-actions {
+      .vp-hero-action-button {
+        border-radius: 8px !important;
+        font-weight: 600 !important;
+        padding: 0.75rem 1.75rem !important;
+        font-size: 1rem !important;
+        transition: all 0.3s ease !important;
+
+        &.primary {
+          background: linear-gradient(135deg, #3a7bd5 0%, #2563eb 100%) !important;
+          border-color: transparent !important;
+          box-shadow: 0 4px 15px rgba(37, 99, 235, 0.35);
+
+          &:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(37, 99, 235, 0.45) !important;
+          }
+        }
+
+        &.secondary {
+          border: 2px solid #3a7bd5 !important;
+          color: #3a7bd5 !important;
+          background: transparent !important;
+
+          &:hover {
+            background: rgba(58, 123, 213, 0.08) !important;
+            transform: translateY(-2px);
+          }
+        }
+      }
+    }
+  }
+}
+
+/* ---------- Feature Cards ---------- */
+.vp-features {
+  border-top: none !important;
+  padding: 1.5rem 0 2rem !important;
+  max-width: 960px;
+  margin: 0 auto !important;
+}
+
+.vp-feature {
+  border: 1px solid transparent !important;
+  border-radius: 16px !important;
+  padding: 2rem !important;
+  background: var(--c-bg) !important;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.06),
+    0 10px 25px -5px rgba(0, 0, 0, 0.08) !important;
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1) !important;
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #3a7bd5, #00d2ff);
+    opacity: 0;
+    transition: opacity 0.35s ease;
+  }
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow:
+      0 12px 24px -8px rgba(0, 0, 0, 0.12),
+      0 20px 40px -12px rgba(0, 0, 0, 0.1) !important;
+    border-color: rgba(58, 123, 213, 0.15) !important;
+
+    &::before {
+      opacity: 1;
+    }
+  }
+
+  h2 {
+    font-size: 1.2rem !important;
+    font-weight: 700 !important;
+    color: var(--c-text) !important;
+    margin-bottom: 0.5rem;
+    border: none !important;
+  }
+
+  p {
+    color: var(--c-text-lighter) !important;
+    line-height: 1.65;
+    font-size: 0.95rem;
+  }
+}
+
+/* ---------- Homepage Content Area ---------- */
+/* Content is in a wrapper div after .vp-features */
+.vp-home > div:not(.vp-hero):not(.vp-features):not(.vp-footer) {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 2rem 2rem;
+
+  /* Section headings */
+  h2 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    text-align: center;
+    margin-top: 2.5rem;
+    margin-bottom: 0.5rem;
+    color: var(--c-text);
+    border: none;
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
+
+  /* Subtitle paragraphs */
+  > div > p {
+    text-align: center;
+    color: var(--c-text-lighter);
+    max-width: 640px;
+    margin: 0 auto 2rem;
+    line-height: 1.7;
+  }
+
+  /* Explore-the-docs links section */
+  ul {
+    list-style: none;
+    padding: 0 !important;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+    max-width: 700px;
+    margin: 1.5rem auto 2rem;
+
+    li {
+      background: var(--c-bg);
+      border: 1px solid var(--c-border);
+      border-radius: 10px;
+      transition: all 0.3s ease;
+
+      &:hover {
+        border-color: #3a7bd5;
+        box-shadow: 0 4px 12px rgba(58, 123, 213, 0.12);
+        transform: translateY(-2px);
+      }
+
+      a {
+        display: block;
+        padding: 0.85rem 1.15rem;
+        font-weight: 500;
+        color: #3a7bd5 !important;
+        text-decoration: none;
+
+        &::before {
+          content: '\2192\00a0';
+          opacity: 0.5;
+        }
+      }
+    }
+  }
+}
+
+/* ---------- Footer ---------- */
+.vp-home .vp-footer {
+  border-top: 1px solid var(--c-border);
+}
+
+/* ---------- Dark mode overrides ---------- */
+[data-theme='dark'] {
+  .vp-home .vp-hero h1 {
+    background: linear-gradient(135deg, #60a5fa 0%, #38bdf8 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    filter: drop-shadow(0 2px 8px rgba(96, 165, 250, 0.2));
+  }
+
+  .vp-home .vp-hero .vp-hero-actions .vp-hero-action-button {
+    &.primary {
+      background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%) !important;
+      box-shadow: 0 4px 15px rgba(59, 130, 246, 0.3);
+
+      &:hover {
+        box-shadow: 0 6px 20px rgba(59, 130, 246, 0.45) !important;
+      }
+    }
+
+    &.secondary {
+      border-color: #60a5fa !important;
+      color: #60a5fa !important;
+
+      &:hover {
+        background: rgba(96, 165, 250, 0.1) !important;
+      }
+    }
+  }
+
+  .vp-feature {
+    background: var(--c-bg-light) !important;
+    box-shadow:
+      0 4px 6px -1px rgba(0, 0, 0, 0.2),
+      0 10px 25px -5px rgba(0, 0, 0, 0.25) !important;
+
+    &:hover {
+      box-shadow:
+        0 12px 24px -8px rgba(0, 0, 0, 0.35),
+        0 20px 40px -12px rgba(0, 0, 0, 0.3) !important;
+      border-color: rgba(96, 165, 250, 0.25) !important;
+    }
+  }
+
+  .vp-home > div:not(.vp-hero):not(.vp-features):not(.vp-footer) {
+    ul li {
+      background: var(--c-bg-light);
+      border-color: var(--c-border);
+
+      &:hover {
+        border-color: #60a5fa;
+        box-shadow: 0 4px 12px rgba(96, 165, 250, 0.15);
+      }
+
+      a {
+        color: #60a5fa !important;
+      }
+    }
+  }
+}

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -20,79 +20,86 @@ features:
 footer: MIT Licensed • Built for performance
 ---
 
+<script setup>
+const codeTabs = [
+  {
+    title: 'Extractors',
+    code: [
+      'use volga::{App, Json, ok};',
+      'use serde::Deserialize;',
+      '',
+      '#[derive(Deserialize)]',
+      'struct User {',
+      '    name: String,',
+      '    age: i32,',
+      '}',
+      '',
+      '#[tokio::main]',
+      'async fn main() -> std::io::Result<()> {',
+      '    let mut app = App::new();',
+      '',
+      '    app.map_post("/hello", |user: Json<User>| async move {',
+      '        ok!("Hello {}!", user.name)',
+      '    });',
+      '',
+      '    app.run().await',
+      '}',
+    ].join('\n')
+  },
+  {
+    title: 'Dependency Injection',
+    code: [
+      'use volga::{App, di::Dc, ok, not_found};',
+      'use std::{',
+      '    collections::HashMap,',
+      '    sync::{Arc, Mutex},',
+      '};',
+      '',
+      '#[derive(Clone, Default)]',
+      'struct InMemoryCache {',
+      '    inner: Arc<Mutex<HashMap<String, String>>>,',
+      '}',
+      '',
+      '#[tokio::main]',
+      'async fn main() -> std::io::Result<()> {',
+      '    let mut app = App::new();',
+      '    app.add_singleton(InMemoryCache::default());',
+      '',
+      '    app.map_get("/user/{id}", |id: String, cache: Dc<InMemoryCache>| async move {',
+      '        let user = cache.inner.lock().unwrap().get(&id);',
+      '        match user {',
+      '            Some(user) => ok!(user),',
+      '            None => not_found!("User not found"),',
+      '        }',
+      '    });',
+      '',
+      '    app.run().await',
+      '}',
+    ].join('\n')
+  },
+  {
+    title: 'Rate Limiting',
+    code: [
+      'use volga::{App, rate_limiting::{by, TokenBucket}};',
+      '',
+      'let burst = TokenBucket::new(2, 0.5).with_name("burst");',
+      'let mut app = App::new()',
+      '  .with_token_bucket(burst);',
+      '',
+      'app.map_get("/upload", upload_handler)',
+      '    .token_bucket(by::ip().using("burst"));',
+    ].join('\n')
+  }
+]
+</script>
+
 ## Build APIs that scale with confidence
 
 Volga ships with performance-friendly primitives and modern developer ergonomics. From routing to middleware and advanced infrastructure features, you can scale from a single endpoint to a full microservice surface without rewriting core pieces.
 
 ## Examples that hook developers fast
 
-### Extractors that keep handlers clean
-
-```rust
-use volga::{App, Json, ok};
-use serde::Deserialize;
-
-#[derive(Deserialize)]
-struct User {
-    name: String,
-    age: i32,
-}
-
-#[tokio::main]
-async fn main() -> std::io::Result<()> {
-    let mut app = App::new();
-
-    app.map_post("/hello", |user: Json<User>| async move {
-        ok!("Hello {}!", user.name)
-    });
-
-    app.run().await
-}
-```
-
-### Dependency Injection that feels native
-
-```rust
-use volga::{App, di::Dc, ok, not_found};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
-
-#[derive(Clone, Default)]
-struct InMemoryCache {
-    inner: Arc<Mutex<HashMap<String, String>>>,
-}
-
-#[tokio::main]
-async fn main() -> std::io::Result<()> {
-    let mut app = App::new();
-    app.add_singleton(InMemoryCache::default());
-
-    app.map_get("/user/{id}", |id: String, cache: Dc<InMemoryCache>| async move {
-        let user = cache.inner.lock().unwrap().get(&id);
-        match user {
-            Some(user) => ok!(user),
-            None => not_found!("User not found"),
-        }
-    });
-
-    app.run().await
-}
-```
-
-### Rate Limiting with named policies
-
-```rust
-use volga::{App, rate_limiting::{by, TokenBucket}};
-
-let burst = TokenBucket::new(2, 0.5).with_name("burst");
-let mut app = App::new()
-  .with_token_bucket(burst);
-
-app.map_get("/upload", upload_handler)
-    .token_bucket(by::ip().using("burst"));
-```
+<CodeShowcase :tabs="codeTabs" />
 
 ## Explore the docs
 

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -20,80 +20,88 @@ features:
 footer: MIT Licensed • Сфокусирован на производительности
 ---
 
+<script setup>
+const codeTabs = [
+  {
+    title: 'DI',
+    code: [
+      'use volga::{App, di::Dc, ok, not_found};',
+      'use std::{',
+      '    collections::HashMap,',
+      '    sync::{Arc, Mutex},',
+      '};',
+      '',
+      '#[derive(Clone, Default)]',
+      'struct InMemoryCache {',
+      '    inner: Arc<Mutex<HashMap<String, String>>>,',
+      '}',
+      '',
+      '#[tokio::main]',
+      'async fn main() -> std::io::Result<()> {',
+      '    let mut app = App::new();',
+      '    app.add_singleton(InMemoryCache::default());',
+      '',
+      '    app.map_get("/user/{id}", |id: String, cache: Dc<InMemoryCache>| async move {',
+      '        let user = cache.inner.lock().unwrap().get(&id);',
+      '        match user {',
+      '            Some(user) => ok!(user),',
+      '            None => not_found!("User not found"),',
+      '        }',
+      '    });',
+      '',
+      '    app.run().await',
+      '}',
+    ].join('\n')
+  },
+  {
+    title: 'Rate Limiting',
+    code: [
+      'use std::time::Duration;',
+      'use volga::{App, rate_limiting::{by, FixedWindow}};',
+      '',
+      'let burst = FixedWindow::new(100, Duration::from_secs(30))',
+      '    .with_name("burst");',
+      '',
+      'let mut app = App::new().with_fixed_window(burst);',
+      '',
+      'app.map_get("/upload", upload_handler)',
+      '    .fixed_window(by::ip().using("burst"));',
+    ].join('\n')
+  },
+  {
+    title: 'Extractors',
+    code: [
+      'use volga::{App, Json, ok};',
+      'use serde::Deserialize;',
+      '',
+      '#[derive(Deserialize)]',
+      'struct User {',
+      '    name: String,',
+      '    age: i32,',
+      '}',
+      '',
+      '#[tokio::main]',
+      'async fn main() -> std::io::Result<()> {',
+      '    let mut app = App::new();',
+      '',
+      '    app.map_post("/hello", |user: Json<User>| async move {',
+      '        ok!("Hello {}!", user.name)',
+      '    });',
+      '',
+      '    app.run().await',
+      '}',
+    ].join('\n')
+  }
+]
+</script>
+
 ## Масштабируйте API уверенно
 
 Volga предоставляет производительные примитивы и современные практики разработки. От роутинга до middleware и продвинутой инфраструктуры — масштабируйте сервисы без переписывания базовых вещей.
 
 ## Примеры, которые цепляют
 
-### DI, которое ощущается нативно
-
-```rust
-use volga::{App, di::Dc, ok, not_found};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
-
-#[derive(Clone, Default)]
-struct InMemoryCache {
-    inner: Arc<Mutex<HashMap<String, String>>>,
-}
-
-#[tokio::main]
-async fn main() -> std::io::Result<()> {
-    let mut app = App::new();
-    app.add_singleton(InMemoryCache::default());
-
-    app.map_get("/user/{id}", |id: String, cache: Dc<InMemoryCache>| async move {
-        let user = cache.inner.lock().unwrap().get(&id);
-        match user {
-            Some(user) => ok!(user),
-            None => not_found!("User not found"),
-        }
-    });
-
-    app.run().await
-}
-```
-
-### Rate limiting с именованными политиками
-
-```rust
-use std::time::Duration;
-use volga::{App, rate_limiting::{by, FixedWindow}};
-
-let burst = FixedWindow::new(100, Duration::from_secs(30)).with_name("burst");
-
-let mut app = App::new().with_fixed_window(burst);
-
-app.map_get("/upload", upload_handler)
-    .fixed_window(by::ip().using("burst"));
-```
-
-### Экстракторы, которые держат код чистым
-
-```rust
-use volga::{App, Json, ok};
-use serde::Deserialize;
-
-#[derive(Deserialize)]
-struct User {
-    name: String,
-    age: i32,
-}
-
-#[tokio::main]
-async fn main() -> std::io::Result<()> {
-    let mut app = App::new();
-
-    app.map_post("/hello", |user: Json<User>| async move {
-        ok!("Hello {}!", user.name)
-    });
-
-    app.run().await
-}
-```
+<CodeShowcase :tabs="codeTabs" />
 
 ## Изучайте документацию дальше
 


### PR DESCRIPTION
- Add gradient hero title, styled CTA buttons with shadows and hover effects
- Create CodeShowcase Vue component with tabbed code examples, window dots, and Catppuccin Mocha syntax highlighting theme
- Style feature cards with shadows, rounded corners, and gradient top border on hover
- Style "Explore the docs" links as a responsive card grid
- Full light/dark theme support
- Both EN and RU homepages updated
