### PR TITLE
Fix homepage design: match native theme colors, layout, and code style

### DIFF
--- a/docs/.vuepress/components/CodeShowcase.vue
+++ b/docs/.vuepress/components/CodeShowcase.vue
@@ -11,9 +11,6 @@
       </button>
     </div>
     <div class="code-showcase__card">
-      <div class="code-showcase__window-dots">
-        <span></span><span></span><span></span>
-      </div>
       <div class="code-showcase__content">
         <div
           v-for="(tab, i) in tabs"
@@ -28,50 +25,44 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 
 const props = defineProps({
   tabs: {
     type: Array,
     required: true,
-    // Each tab: { title: string, code: string }
   }
 })
 
 const activeTab = ref(0)
+const usePrism = ref(false)
 
-// Simple Rust syntax highlighter that produces styled spans
+onMounted(() => {
+  // Use PrismJS if available (loaded by VuePress plugin)
+  if (typeof window !== 'undefined' && window.Prism && window.Prism.languages.rust) {
+    usePrism.value = true
+  }
+})
+
+function highlightWithPrism(code) {
+  if (typeof window !== 'undefined' && window.Prism && window.Prism.languages.rust) {
+    return window.Prism.highlight(code, window.Prism.languages.rust, 'rust')
+  }
+  return escapeHtml(code)
+}
+
+// Fallback simple Rust highlighter for SSR
 function highlightRust(code) {
   let html = escapeHtml(code)
-
-  // Comments (// ...)
-  html = html.replace(/(\/\/.*)/g, '<span class="hl-comment">$1</span>')
-
-  // Strings ("...")
-  html = html.replace(/(&quot;(?:[^&]|&(?!quot;))*?&quot;)/g, '<span class="hl-string">$1</span>')
-
-  // Attributes (#[...])
-  html = html.replace(/(#\[[\w:,\s()]*\])/g, '<span class="hl-attr">$1</span>')
-
-  // Macros (word!)
-  html = html.replace(/\b([a-z_]+!)/g, '<span class="hl-macro">$1</span>')
-
-  // Keywords
+  html = html.replace(/(\/\/.*)/g, '<span class="token comment">$1</span>')
+  html = html.replace(/(&quot;(?:[^&]|&(?!quot;))*?&quot;)/g, '<span class="token string">$1</span>')
+  html = html.replace(/(#\[[\w:,\s()]*\])/g, '<span class="token attribute">$1</span>')
+  html = html.replace(/\b([a-z_]+!)/g, '<span class="token macro">$1</span>')
   const keywords = ['use','fn','let','mut','async','move','await','struct','match','Some','None','Ok','Err','pub','mod','impl','self','Self','return','if','else','for','in','while','loop','break','continue','where','type','trait','enum','const','static','ref','as','crate','super','extern','unsafe']
   const kwPattern = new RegExp('\\b(' + keywords.join('|') + ')\\b', 'g')
-  html = html.replace(kwPattern, (m) => {
-    // Don't re-highlight if already inside a span
-    return '<span class="hl-keyword">' + m + '</span>'
-  })
-
-  // Types (PascalCase words)
-  html = html.replace(/\b([A-Z][A-Za-z0-9]*)\b/g, (m) => {
-    return '<span class="hl-type">' + m + '</span>'
-  })
-
-  // Numbers
-  html = html.replace(/\b(\d+(?:\.\d+)?)\b/g, '<span class="hl-number">$1</span>')
-
+  html = html.replace(kwPattern, '<span class="token keyword">$1</span>')
+  html = html.replace(/\b([A-Z][A-Za-z0-9]*)\b/g, '<span class="token class-name">$1</span>')
+  html = html.replace(/\b(\d+(?:\.\d+)?)\b/g, '<span class="token number">$1</span>')
   return html
 }
 
@@ -85,8 +76,8 @@ function escapeHtml(str) {
 
 const highlighted = computed(() =>
   props.tabs.map(tab => {
-    const lines = highlightRust(tab.code).split('\n')
-    return '<pre class="hl-pre"><code>' + lines.join('\n') + '</code></pre>'
+    const html = usePrism.value ? highlightWithPrism(tab.code) : highlightRust(tab.code)
+    return '<pre class="language-rust"><code>' + html + '</code></pre>'
   })
 )
 </script>
@@ -101,140 +92,62 @@ const highlighted = computed(() =>
 .code-showcase__tabs {
   display: flex;
   gap: 0;
-  border-bottom: none;
-  margin-bottom: -1px;
+  margin-bottom: 0;
   position: relative;
   z-index: 2;
-  padding-left: 8px;
+  padding-left: 4px;
 }
 
 .code-showcase__tab {
-  padding: 0.6rem 1.25rem;
+  padding: 0.5rem 1.15rem;
   border: none;
   background: transparent;
-  color: var(--c-text-lighter, #888);
+  color: var(--vp-c-text-mute, #888);
   font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
-  border-radius: 10px 10px 0 0;
-  transition: all 0.25s ease;
+  border-radius: 6px 6px 0 0;
+  transition: all 0.2s ease;
   font-family: inherit;
-  letter-spacing: 0.01em;
 }
 
 .code-showcase__tab:hover {
-  color: var(--c-text, #333);
-  background: rgba(58, 123, 213, 0.06);
+  color: var(--vp-c-text, #333);
 }
 
 .code-showcase__tab.active {
-  background: #1e1e2e;
-  color: #cdd6f4;
+  background: var(--code-c-bg, #ecf4fa);
+  color: var(--vp-c-text, #383a42);
 }
 
-/* Card */
+/* Card — matches native VuePress code blocks */
 .code-showcase__card {
-  background: #1e1e2e;
-  border-radius: 16px;
+  background: var(--code-c-bg, #ecf4fa);
+  border-radius: var(--code-border-radius, 6px);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.18),
-    0 2px 8px rgba(0, 0, 0, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    0 4px 16px rgba(0, 0, 0, 0.08),
+    0 1px 4px rgba(0, 0, 0, 0.05);
   overflow: hidden;
-  position: relative;
-}
-
-/* Window dots */
-.code-showcase__window-dots {
-  display: flex;
-  gap: 7px;
-  padding: 14px 18px 0;
-}
-
-.code-showcase__window-dots span {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  display: block;
-}
-
-.code-showcase__window-dots span:nth-child(1) {
-  background: #f38ba8;
-}
-
-.code-showcase__window-dots span:nth-child(2) {
-  background: #f9e2af;
-}
-
-.code-showcase__window-dots span:nth-child(3) {
-  background: #a6e3a1;
 }
 
 /* Content */
 .code-showcase__content {
-  padding: 0.75rem 0;
-}
-
-.code-showcase__panel :deep(.hl-pre) {
-  margin: 0;
-  padding: 0.75rem 1.5rem 1.25rem;
-  background: transparent;
-  overflow-x: auto;
-  font-size: 0.875rem;
-  line-height: 1.7;
-}
-
-.code-showcase__panel :deep(.hl-pre code) {
-  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace;
-  color: #cdd6f4;
-  background: none;
   padding: 0;
 }
 
-/* Syntax tokens – Catppuccin Mocha inspired */
-.code-showcase__panel :deep(.hl-keyword) {
-  color: #cba6f7;
-  font-weight: 600;
+.code-showcase__panel :deep(pre) {
+  margin: 0;
+  padding: var(--code-padding-y, 1rem) var(--code-padding-x, 1.25rem);
+  background: transparent;
+  overflow-x: auto;
+  font-size: var(--code-font-size, 0.875em);
+  line-height: var(--code-line-height, 1.6);
 }
 
-.code-showcase__panel :deep(.hl-type) {
-  color: #f9e2af;
-}
-
-.code-showcase__panel :deep(.hl-string) {
-  color: #a6e3a1;
-}
-
-.code-showcase__panel :deep(.hl-macro) {
-  color: #89b4fa;
-  font-weight: 600;
-}
-
-.code-showcase__panel :deep(.hl-comment) {
-  color: #6c7086;
-  font-style: italic;
-}
-
-.code-showcase__panel :deep(.hl-number) {
-  color: #fab387;
-}
-
-.code-showcase__panel :deep(.hl-attr) {
-  color: #f38ba8;
-}
-
-/* Subtle glow effect */
-.code-showcase__card::after {
-  content: '';
-  position: absolute;
-  inset: -1px;
-  border-radius: 16px;
-  padding: 1px;
-  background: linear-gradient(135deg, rgba(58, 123, 213, 0.2), rgba(0, 210, 255, 0.1), transparent 60%);
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
+.code-showcase__panel :deep(pre code) {
+  font-family: var(--code-font-family, consolas, monaco, "Andale Mono", "Ubuntu Mono", monospace);
+  color: var(--code-c-text, #383a42);
+  background: none;
+  padding: 0;
 }
 </style>

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -9,16 +9,10 @@
       font-size: 4rem !important;
       font-weight: 800 !important;
       letter-spacing: -0.02em;
-      background: linear-gradient(135deg, #3a7bd5 0%, #00d2ff 100%);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-      filter: drop-shadow(0 2px 4px rgba(58, 123, 213, 0.15));
     }
 
     .vp-hero-description {
       font-size: 1.25rem !important;
-      color: var(--c-text-lightest);
       max-width: 600px;
       margin: 0.5rem auto 0;
       line-height: 1.7;
@@ -33,23 +27,14 @@
         transition: all 0.3s ease !important;
 
         &.primary {
-          background: linear-gradient(135deg, #3a7bd5 0%, #2563eb 100%) !important;
-          border-color: transparent !important;
-          box-shadow: 0 4px 15px rgba(37, 99, 235, 0.35);
-
           &:hover {
             transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(37, 99, 235, 0.45) !important;
+            box-shadow: 0 6px 20px rgba(62, 175, 124, 0.35) !important;
           }
         }
 
         &.secondary {
-          border: 2px solid #3a7bd5 !important;
-          color: #3a7bd5 !important;
-          background: transparent !important;
-
           &:hover {
-            background: rgba(58, 123, 213, 0.08) !important;
             transform: translateY(-2px);
           }
         }
@@ -61,77 +46,68 @@
 /* ---------- Feature Cards ---------- */
 .vp-features {
   border-top: none !important;
-  padding: 1.5rem 0 2rem !important;
+  padding: 1.5rem 2rem 2rem !important;
   max-width: 960px;
   margin: 0 auto !important;
+  display: grid !important;
+  grid-template-columns: repeat(3, 1fr) !important;
+  gap: 1.25rem !important;
+}
+
+@media (max-width: 719px) {
+  .vp-features {
+    grid-template-columns: 1fr !important;
+  }
 }
 
 .vp-feature {
-  border: 1px solid transparent !important;
-  border-radius: 16px !important;
-  padding: 2rem !important;
-  background: var(--c-bg) !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  flex: none !important;
+  border: 1px solid var(--vp-c-border, var(--c-border, #e2e2e3)) !important;
+  border-radius: 12px !important;
+  padding: 1.5rem !important;
+  background: var(--vp-c-bg, #fff) !important;
   box-shadow:
-    0 4px 6px -1px rgba(0, 0, 0, 0.06),
-    0 10px 25px -5px rgba(0, 0, 0, 0.08) !important;
-  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1) !important;
+    0 2px 8px rgba(0, 0, 0, 0.04),
+    0 4px 16px rgba(0, 0, 0, 0.06) !important;
+  transition: all 0.3s ease !important;
   position: relative;
   overflow: hidden;
 
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 4px;
-    background: linear-gradient(90deg, #3a7bd5, #00d2ff);
-    opacity: 0;
-    transition: opacity 0.35s ease;
-  }
-
   &:hover {
-    transform: translateY(-4px);
+    transform: translateY(-3px);
     box-shadow:
-      0 12px 24px -8px rgba(0, 0, 0, 0.12),
-      0 20px 40px -12px rgba(0, 0, 0, 0.1) !important;
-    border-color: rgba(58, 123, 213, 0.15) !important;
-
-    &::before {
-      opacity: 1;
-    }
+      0 8px 24px rgba(0, 0, 0, 0.08),
+      0 4px 12px rgba(0, 0, 0, 0.06) !important;
   }
 
   h2 {
-    font-size: 1.2rem !important;
+    font-size: 1.1rem !important;
     font-weight: 700 !important;
-    color: var(--c-text) !important;
     margin-bottom: 0.5rem;
     border: none !important;
+    padding: 0 !important;
   }
 
   p {
-    color: var(--c-text-lighter) !important;
     line-height: 1.65;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
   }
 }
 
 /* ---------- Homepage Content Area ---------- */
-/* Content is in a wrapper div after .vp-features */
 .vp-home > div:not(.vp-hero):not(.vp-features):not(.vp-footer) {
   max-width: 960px;
   margin: 0 auto;
   padding: 0 2rem 2rem;
 
-  /* Section headings */
   h2 {
     font-size: 1.75rem;
     font-weight: 700;
     text-align: center;
     margin-top: 2.5rem;
     margin-bottom: 0.5rem;
-    color: var(--c-text);
     border: none;
 
     a {
@@ -140,16 +116,15 @@
     }
   }
 
-  /* Subtitle paragraphs */
   > div > p {
     text-align: center;
-    color: var(--c-text-lighter);
+    color: var(--vp-c-text-mute, var(--c-text-lighter));
     max-width: 640px;
     margin: 0 auto 2rem;
     line-height: 1.7;
   }
 
-  /* Explore-the-docs links section */
+  /* Explore-the-docs links */
   ul {
     list-style: none;
     padding: 0 !important;
@@ -160,14 +135,13 @@
     margin: 1.5rem auto 2rem;
 
     li {
-      background: var(--c-bg);
-      border: 1px solid var(--c-border);
-      border-radius: 10px;
+      border: 1px solid var(--vp-c-border, var(--c-border, #e2e2e3));
+      border-radius: 8px;
       transition: all 0.3s ease;
 
       &:hover {
-        border-color: #3a7bd5;
-        box-shadow: 0 4px 12px rgba(58, 123, 213, 0.12);
+        border-color: var(--vp-c-accent-bg, #3eaf7c);
+        box-shadow: 0 2px 8px rgba(62, 175, 124, 0.12);
         transform: translateY(-2px);
       }
 
@@ -175,7 +149,7 @@
         display: block;
         padding: 0.85rem 1.15rem;
         font-weight: 500;
-        color: #3a7bd5 !important;
+        color: var(--vp-c-accent, #299764) !important;
         text-decoration: none;
 
         &::before {
@@ -189,64 +163,36 @@
 
 /* ---------- Footer ---------- */
 .vp-home .vp-footer {
-  border-top: 1px solid var(--c-border);
+  border-top: 1px solid var(--vp-c-border, var(--c-border, #e2e2e3));
 }
 
 /* ---------- Dark mode overrides ---------- */
 [data-theme='dark'] {
-  .vp-home .vp-hero h1 {
-    background: linear-gradient(135deg, #60a5fa 0%, #38bdf8 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    filter: drop-shadow(0 2px 8px rgba(96, 165, 250, 0.2));
-  }
-
-  .vp-home .vp-hero .vp-hero-actions .vp-hero-action-button {
-    &.primary {
-      background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%) !important;
-      box-shadow: 0 4px 15px rgba(59, 130, 246, 0.3);
-
-      &:hover {
-        box-shadow: 0 6px 20px rgba(59, 130, 246, 0.45) !important;
-      }
-    }
-
-    &.secondary {
-      border-color: #60a5fa !important;
-      color: #60a5fa !important;
-
-      &:hover {
-        background: rgba(96, 165, 250, 0.1) !important;
-      }
-    }
-  }
-
   .vp-feature {
-    background: var(--c-bg-light) !important;
+    background: var(--vp-c-bg-elv, #202127) !important;
+    border-color: var(--vp-c-border, #2e2e32) !important;
     box-shadow:
-      0 4px 6px -1px rgba(0, 0, 0, 0.2),
-      0 10px 25px -5px rgba(0, 0, 0, 0.25) !important;
+      0 2px 8px rgba(0, 0, 0, 0.15),
+      0 4px 16px rgba(0, 0, 0, 0.2) !important;
 
     &:hover {
       box-shadow:
-        0 12px 24px -8px rgba(0, 0, 0, 0.35),
-        0 20px 40px -12px rgba(0, 0, 0, 0.3) !important;
-      border-color: rgba(96, 165, 250, 0.25) !important;
+        0 8px 24px rgba(0, 0, 0, 0.25),
+        0 4px 12px rgba(0, 0, 0, 0.2) !important;
     }
   }
 
   .vp-home > div:not(.vp-hero):not(.vp-features):not(.vp-footer) {
     ul li {
-      background: var(--c-bg-light);
-      border-color: var(--c-border);
+      border-color: var(--vp-c-border, #2e2e32);
 
       &:hover {
-        border-color: #60a5fa;
-        box-shadow: 0 4px 12px rgba(96, 165, 250, 0.15);
+        border-color: var(--vp-c-accent-bg, #3aa675);
+        box-shadow: 0 2px 8px rgba(58, 166, 117, 0.15);
       }
 
       a {
-        color: #60a5fa !important;
+        color: var(--vp-c-accent-bg, #3aa675) !important;
       }
     }
   }

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -106,6 +106,6 @@ Volga предоставляет производительные примити
 ## Изучайте документацию дальше
 
 - [Быстрый старт](/volga-docs/ru/getting-started/quick-start.html)
-- [Dependency Injection](/volga-docs/ru/advanced-patterns/di.html)
-- [Rate Limiting](/volga-docs/ru/middleware-infrastructure/rate-limiting.html)
-- [Handling JSON](/volga-docs/ru/requests-responses/json-payload.html)
+- [Внедрение зависимостей](/volga-docs/ru/advanced-patterns/di.html)
+- [Ограничение запросов](/volga-docs/ru/middleware-infrastructure/rate-limiting.html)
+- [Работа с JSON](/volga-docs/ru/requests-responses/json-payload.html)


### PR DESCRIPTION
- Replace custom blue gradients with native VuePress green accent (#3eaf7c)
- Fix features grid: 3 equal columns, stacking vertically on mobile
- Restyle CodeShowcase to match native PrismJS code blocks (one-dark/one-light)
- Remove decorative window dots from code showcase, add shadow instead
- Use Prism.js for syntax highlighting when available (matches guides)
- Translate RU "Explore the docs" links to Russian
