### PR TITLE
Fix feature cards overlap and remove borders from doc links

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -61,6 +61,7 @@
 }
 
 .vp-feature {
+  box-sizing: border-box !important;
   width: 100% !important;
   max-width: 100% !important;
   flex: none !important;
@@ -135,19 +136,15 @@
     margin: 1.5rem auto 2rem;
 
     li {
-      border: 1px solid var(--vp-c-border, var(--c-border, #e2e2e3));
-      border-radius: 8px;
       transition: all 0.3s ease;
 
       &:hover {
-        border-color: var(--vp-c-accent-bg, #3eaf7c);
-        box-shadow: 0 2px 8px rgba(62, 175, 124, 0.12);
-        transform: translateY(-2px);
+        transform: translateY(-1px);
       }
 
       a {
         display: block;
-        padding: 0.75rem 1rem;
+        padding: 0.5rem 0;
         font-weight: 500;
         color: var(--vp-c-accent, #299764) !important;
         text-decoration: none;
@@ -156,6 +153,10 @@
         &::before {
           content: '\2192\00a0';
           opacity: 0.5;
+        }
+
+        &:hover {
+          text-decoration: underline;
         }
       }
     }
@@ -192,17 +193,8 @@
   }
 
   .vp-home > div:not(.vp-hero):not(.vp-features):not(.vp-footer) {
-    ul li {
-      border-color: var(--vp-c-border, #2e2e32);
-
-      &:hover {
-        border-color: var(--vp-c-accent-bg, #3aa675);
-        box-shadow: 0 2px 8px rgba(58, 166, 117, 0.15);
-      }
-
-      a {
-        color: var(--vp-c-accent-bg, #3aa675) !important;
-      }
+    ul li a {
+      color: var(--vp-c-accent-bg, #3aa675) !important;
     }
   }
 }


### PR DESCRIPTION
- Add box-sizing: border-box to .vp-feature so padding doesn't overflow grid columns
- Remove borders/shadows from "Explore the docs" links, keep as plain styled links