### PR TITLE
Fix feature cards equal height and mobile alignment

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -51,12 +51,15 @@
   margin: 0 auto !important;
   display: grid !important;
   grid-template-columns: repeat(3, 1fr) !important;
+  align-items: stretch !important;
   gap: 1.25rem !important;
 }
 
 @media (max-width: 719px) {
   .vp-features {
     grid-template-columns: 1fr !important;
+    padding: 1rem 1.5rem 1.5rem !important;
+    justify-items: center !important;
   }
 }
 
@@ -64,6 +67,7 @@
   box-sizing: border-box !important;
   width: 100% !important;
   max-width: 100% !important;
+  min-height: 0 !important;
   flex: none !important;
   border: 1px solid var(--vp-c-border, var(--c-border, #e2e2e3)) !important;
   border-radius: 12px !important;


### PR DESCRIPTION
- Add align-items: stretch so all 3 cards match tallest card height
- Add padding and justify-items: center on mobile breakpoint to prevent cards sticking to the right edge

https://claude.ai/code/session_01MdmAFZCcYJH4LMmjpAvuzQ