### PR TITLE
Improve homepage feature cards and code blocks styling

### DIFF
--- a/docs/.vuepress/components/CodeShowcase.vue
+++ b/docs/.vuepress/components/CodeShowcase.vue
@@ -48,7 +48,7 @@ function escapeHtml(str) {
 // so the globally loaded one-dark / one-light theme CSS applies.
 function highlightRust(code) {
   const lines = code.split('\n')
-  return lines.map(line => {
+  return lines.map((line, idx) => {
     let html = escapeHtml(line)
 
     // Comments
@@ -81,7 +81,7 @@ function highlightRust(code) {
     // Namespace separators
     html = html.replace(/::/g, '<span class="token punctuation">::</span>')
 
-    return '<span class="line">' + html + '</span>'
+    return '<span class="line"><span class="line-number">' + (idx + 1) + '</span>' + html + '</span>'
   }).join('\n')
 }
 
@@ -131,13 +131,14 @@ const highlighted = computed(() =>
   color: var(--vp-c-text, #383a42);
 }
 
-/* Card — matches native VuePress code blocks */
+/* Card — matches feature card style */
 .code-showcase__card {
   background: var(--code-c-bg, #ecf4fa);
-  border-radius: var(--code-border-radius, 6px);
+  border: 1px solid var(--vp-c-border, var(--c-border, #e2e2e3));
+  border-radius: 12px;
   box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.08),
-    0 1px 4px rgba(0, 0, 0, 0.05);
+    0 2px 8px rgba(0, 0, 0, 0.04),
+    0 4px 16px rgba(0, 0, 0, 0.06);
   overflow: hidden;
 }
 
@@ -160,5 +161,20 @@ const highlighted = computed(() =>
   color: var(--code-c-text, #383a42);
   background: none;
   padding: 0;
+}
+
+.code-showcase__panel :deep(.line) {
+  display: block;
+}
+
+.code-showcase__panel :deep(.line-number) {
+  display: inline-block;
+  width: 2em;
+  margin-right: 1.25em;
+  text-align: right;
+  color: var(--vp-c-text-mute, #aaa);
+  user-select: none;
+  font-size: 0.9em;
+  opacity: 0.5;
 }
 </style>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -157,6 +157,7 @@ export default defineUserConfig({
         dark: 'one-dark',
         light: 'one-light',
       },
+      lineNumbers: true,
     }),
   ],
 })

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -51,12 +51,15 @@
   margin: 0 auto !important;
   display: grid !important;
   grid-template-columns: repeat(3, 1fr) !important;
+  align-items: stretch !important;
   gap: 1.25rem !important;
 }
 
 @media (max-width: 719px) {
   .vp-features {
     grid-template-columns: 1fr !important;
+    padding: 1rem 1.5rem 1.5rem !important;
+    justify-items: center !important;
   }
 }
 
@@ -64,6 +67,7 @@
   box-sizing: border-box !important;
   width: 100% !important;
   max-width: 100% !important;
+  min-height: 0 !important;
   flex: none !important;
   border: 1px solid var(--vp-c-border, var(--c-border, #e2e2e3)) !important;
   border-radius: 12px !important;
@@ -169,6 +173,23 @@
       grid-template-columns: 1fr;
     }
   }
+}
+
+/* ---------- Code Blocks ---------- */
+div[class*='language-'] {
+  border: 1px solid var(--vp-c-border, var(--c-border, #e2e2e3)) !important;
+  border-radius: 12px !important;
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.04),
+    0 4px 16px rgba(0, 0, 0, 0.06) !important;
+  overflow: hidden;
+}
+
+[data-theme='dark'] div[class*='language-'] {
+  border-color: var(--vp-c-border, #2e2e32) !important;
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.15),
+    0 4px 16px rgba(0, 0, 0, 0.2) !important;
 }
 
 /* ---------- Footer ---------- */


### PR DESCRIPTION
- Fix equal height for feature cards (align-items: stretch)
- Fix mobile alignment: cards no longer stick to right edge on narrow screens
- Add line numbers to code blocks via prismjsPlugin lineNumbers: true
- Add border + box-shadow to code blocks matching feature card style

https://claude.ai/code/session_01MdmAFZCcYJH4LMmjpAvuzQ