### PR TITLE
Fix CodeShowcase double line spacing

### DIFF
--- a/docs/.vuepress/components/CodeShowcase.vue
+++ b/docs/.vuepress/components/CodeShowcase.vue
@@ -157,18 +157,4 @@ const highlighted = computed(() =>
   margin: 0 !important;
 }
 
-.code-showcase__panel :deep(.line) {
-  display: block;
-}
-
-.code-showcase__panel :deep(.line-number) {
-  display: inline-block;
-  width: 2em;
-  margin-right: 1.25em;
-  text-align: right;
-  color: var(--vp-c-text-mute, #aaa);
-  user-select: none;
-  font-size: 0.9em;
-  opacity: 0.5;
-}
 </style>


### PR DESCRIPTION
Remove leftover display:block on .line and custom .line-number styles. In <pre> (white-space:pre), display:block on inline spans causes each line to render with an extra blank line. PrismJS CSS handles all line-number styling natively.

https://claude.ai/code/session_01MdmAFZCcYJH4LMmjpAvuzQ