### PR TITLE
Claude/refine light theme styling l pr jn

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -214,13 +214,13 @@ div[class*='language-'] {
 }
 
 /* ---------- Light mode logo adaptation ---------- */
+/* drop-shadow follows the PNG alpha channel (not a box),          */
+/* giving the gear soft layered depth instead of cut-out edges.    */
 :root:not([data-theme='dark']) .vp-hero-image {
   filter:
-    drop-shadow(0 4px 16px rgba(0, 0, 0, 0.12))
-    brightness(1.04)
-    contrast(0.88)
-    saturate(1.1);
-  opacity: 0.92;
+    drop-shadow(0 2px 6px rgba(0, 0, 0, 0.18))
+    drop-shadow(0 8px 28px rgba(0, 0, 0, 0.14))
+    drop-shadow(0 16px 48px rgba(0, 0, 0, 0.08));
 }
 
 /* ---------- Dark mode overrides ---------- */

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -3,7 +3,7 @@ home: true
 title: Volga
 heroText: Volga
 heroImage: /volga-logo.png
-heroImageDark: /volga-logo-dark.png
+heroImageDark: /volga-logo.png
 tagline: Fast, async-first web framework for Rust built on tokio + hyper.
 actions:
   - text: Get Started

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -3,7 +3,7 @@ home: true
 title: Волга
 heroText: Волга
 heroImage: /volga-logo.png
-heroImageDark: /volga-logo-dark.png
+heroImageDark: /volga-logo.png
 tagline: Быстрый async-first веб-фреймворк для Rust на базе tokio + hyper.
 actions:
   - text: Быстрый старт


### PR DESCRIPTION
- Revert heroImageDark to transparent volga-logo.png — the dark-background PNG was causing a visible dark square in dark mode; transparent logo blends naturally with the dark page background as it did before
- Replace light mode logo filter with layered drop-shadow only (no brightness/contrast tweaks) — drop-shadow follows the PNG alpha channel so it adds soft layered depth around the gear shape instead of a harsh cut-out look

https://claude.ai/code/session_01PrNYM94inGpL15uGAbmTZC