### PR TITLE
Add logo and Russo One font to navbar brand

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -26,6 +26,8 @@ export default defineUserConfig({
     smoothScroll: true,
     colorMode: 'auto',
     colorModeSwitch: true,
+    logo: '/volga-logo-light.png',
+    logoDark: '/volga-logo.png',
     locales: {
       '/en/': {
         selectLanguageName: 'English',

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -55,6 +55,22 @@
   }
 }
 
+/* ---------- Navbar Brand ---------- */
+.vp-navbar-brand {
+  .vp-navbar-brand-logo {
+    height: 28px !important;
+    width: auto !important;
+    margin-right: 0.5rem;
+  }
+
+  .vp-navbar-brand-title {
+    font-family: 'Russo One', sans-serif !important;
+    font-weight: 400 !important;
+    letter-spacing: 0.08em !important;
+    text-transform: uppercase;
+  }
+}
+
 /* ---------- Feature Cards ---------- */
 .vp-features {
   border-top: none !important;


### PR DESCRIPTION
- Wire logo/logoDark in theme config: light uses volga-logo-light.png, dark uses the original transparent PNG
- Style .vp-navbar-brand-logo to 28px height
- Apply Russo One + uppercase + letter-spacing to .vp-navbar-brand-title to match the hero heading treatment

https://claude.ai/code/session_01PrNYM94inGpL15uGAbmTZC