### PR TITLE
Fix navbar brand CSS class names

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -56,19 +56,16 @@
 }
 
 /* ---------- Navbar Brand ---------- */
-.vp-navbar-brand {
-  .vp-navbar-brand-logo {
-    height: 28px !important;
-    width: auto !important;
-    margin-right: 0.5rem;
-  }
+.vp-site-logo {
+  height: 28px !important;
+  width: auto !important;
+}
 
-  .vp-navbar-brand-title {
-    font-family: 'Russo One', sans-serif !important;
-    font-weight: 400 !important;
-    letter-spacing: 0.08em !important;
-    text-transform: uppercase;
-  }
+.vp-site-name {
+  font-family: 'Russo One', sans-serif !important;
+  font-weight: 400 !important;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase;
 }
 
 /* ---------- Feature Cards ---------- */


### PR DESCRIPTION
Theme uses .vp-site-logo and .vp-site-name, not .vp-navbar-brand-*. Update selectors accordingly so Russo One font and uppercase apply.

https://claude.ai/code/session_01PrNYM94inGpL15uGAbmTZC