### PR TITLE
Fix navbar logo alignment; rename button to "API Docs"

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -56,11 +56,6 @@
 }
 
 /* ---------- Navbar Brand ---------- */
-.vp-site-logo {
-  height: 28px !important;
-  width: auto !important;
-}
-
 .vp-site-name {
   font-family: 'Russo One', sans-serif !important;
   font-weight: 400 !important;

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -9,7 +9,7 @@ actions:
   - text: Get Started
     link: /en/getting-started/quick-start.html
     type: primary
-  - text: View API Docs
+  - text: API Docs
     link: https://docs.rs/volga/latest/volga/
     type: secondary
 features:


### PR DESCRIPTION
Remove height override on .vp-site-logo — the theme already sizes it correctly via --navbar-line-height; the 28px override was making it smaller and breaking vertical alignment.

Rename hero action button from "View API Docs" to "API Docs" in EN homepage to match the shorter RU variant.

https://claude.ai/code/session_01PrNYM94inGpL15uGAbmTZC