### PR TITLE
Add documentation for parameterized middleware

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -63,7 +63,7 @@ export default defineUserConfig({
           {
             text: 'Middleware & Infrastructure',
             prefix: '/en/middleware-infrastructure/',
-            children: ['middleware', 'middlewares', 'compression', 'decompression', 'cors', 'static-files', 'rate-limiting', 'config-files'],
+            children: ['middleware', 'middlewares', 'parameterized-middleware', 'compression', 'decompression', 'cors', 'static-files', 'rate-limiting', 'config-files'],
           },
           {
             text: 'Security & Access',
@@ -121,7 +121,7 @@ export default defineUserConfig({
           {
             text: 'Middleware и инфраструктура',
             prefix: '/ru/middleware-infrastructure/',
-            children: ['middleware', 'middlewares', 'compression', 'decompression', 'cors', 'static-files', 'rate-limiting', 'config-files'],
+            children: ['middleware', 'middlewares', 'parameterized-middleware', 'compression', 'decompression', 'cors', 'static-files', 'rate-limiting', 'config-files'],
           },
           {
             text: 'Безопасность и доступ',

--- a/docs/en/middleware-infrastructure/parameterized-middleware.md
+++ b/docs/en/middleware-infrastructure/parameterized-middleware.md
@@ -1,0 +1,145 @@
+# Parameterized Middleware
+
+In addition to inline closure-based middleware registered via [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) and [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with), Volga also supports registering middleware as reusable, configurable types through the [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach) method.
+
+This approach is ideal when your middleware needs its own state, configuration, or is meant to be reused across multiple applications.
+
+## Overview
+
+A parameterized middleware is a regular Rust type (typically a `struct`) that implements the [`Middleware`](https://docs.rs/volga/latest/volga/middleware/trait.Middleware.html) trait. The type holds any configuration or shared state the middleware needs, and its [`call()`](https://docs.rs/volga/latest/volga/middleware/trait.Middleware.html#tymethod.call) method contains the middleware logic.
+
+This is very similar to middleware patterns found in other ecosystems (for example, Tower layers, ASP.NET Core middleware, or Express.js classes).
+
+## The `Middleware` Trait
+
+The trait is defined as follows:
+```rust
+pub trait Middleware: Send + Sync + 'static {
+    fn call(
+        &self,
+        ctx: HttpContext,
+        next: NextFn,
+    ) -> impl Future<Output = HttpResult> + Send + 'static;
+}
+```
+
+Any type implementing this trait can be passed to [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach).
+
+## Example: A `Timeout` Middleware
+
+Here is a small middleware that adds an artificial delay before the request is processed further. Its duration is configurable at registration time:
+```rust
+use std::time::Duration;
+use volga::{App, HttpResult, middleware::{HttpContext, NextFn, Middleware}};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // Register the parameterized middleware
+    app.attach(Timeout {
+        duration: Duration::from_secs(1),
+    });
+
+    app.map_get("/hello", || async { "Hello, World!" });
+
+    app.run().await
+}
+
+struct Timeout {
+    duration: Duration,
+}
+
+impl Middleware for Timeout {
+    fn call(&self, ctx: HttpContext, next: NextFn) -> impl Future<Output = HttpResult> + 'static {
+        let duration = self.duration;
+        async move {
+            tokio::time::sleep(duration).await;
+            next(ctx).await
+        }
+    }
+}
+```
+
+The `Timeout` struct carries its configuration (`duration`) and implements the middleware logic inside `call()`. You can instantiate it multiple times with different durations, or share the same instance across routes.
+
+## .wrap() vs .attach()
+
+Both methods register middleware operating on the full [`HttpContext`](https://docs.rs/volga/latest/volga/middleware/struct.HttpContext.html), but they target different use cases:
+
+- [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) is optimized for short, inline closures. No type annotations on `ctx` and `next` are required.
+- [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach) is intended for reusable, parameterized middleware types — typically `struct`s that implement the [`Middleware`](https://docs.rs/volga/latest/volga/middleware/trait.Middleware.html) trait.
+
+::: tip
+Use [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) for quick inline middleware and [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach) when you want to package middleware as a named, configurable type you can reuse.
+:::
+
+`attach()` also accepts closures, but type annotations on the arguments are required:
+```rust
+use volga::{App, middleware::{HttpContext, NextFn}};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.attach(|ctx: HttpContext, next: NextFn| async move {
+        next(ctx).await
+    });
+
+    app.run().await
+}
+```
+
+## Registering on Routes and Route Groups
+
+Parameterized middleware can also be attached to individual routes and [route groups](../getting-started/route-groups.md), not just to the entire application:
+```rust
+use std::time::Duration;
+use volga::{App, HttpResult, middleware::{HttpContext, NextFn, Middleware}};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // Attach to a single route
+    app
+        .map_get("/hello", || async { "Hello, World!" })
+        .attach(Timeout { duration: Duration::from_secs(1) });
+
+    // Attach to a route group
+    {
+        let mut api = app.map_group("/api");
+        api.attach(Timeout { duration: Duration::from_secs(2) });
+        api.map_get("/ping", || async { "pong" });
+    }
+
+    app.run().await
+}
+
+struct Timeout {
+    duration: Duration,
+}
+
+impl Middleware for Timeout {
+    fn call(&self, ctx: HttpContext, next: NextFn) -> impl Future<Output = HttpResult> + 'static {
+        let duration = self.duration;
+        async move {
+            tokio::time::sleep(duration).await;
+            next(ctx).await
+        }
+    }
+}
+```
+
+## When to Prefer Parameterized Middleware
+
+Reach for [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach) and a dedicated type when:
+
+- The middleware needs **configuration** at registration time (timeouts, limits, feature flags, etc.).
+- The middleware should be **reusable** across projects or crates.
+- The middleware holds **shared state**, counters, or handles to external systems.
+- You want to **unit test** the middleware independently of a running application.
+
+For simple, one-off transformations, keeping the logic inline with [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) or [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with) is typically more concise.
+
+Built-in features such as [CORS](./cors.md), [authentication](../security-access/auth.md) and [rate limiting](./rate-limiting.md) are themselves implemented as parameterized middleware on top of [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach).

--- a/docs/en/middleware-infrastructure/parameterized-middleware.md
+++ b/docs/en/middleware-infrastructure/parameterized-middleware.md
@@ -107,11 +107,10 @@ async fn main() -> std::io::Result<()> {
         .attach(Timeout { duration: Duration::from_secs(1) });
 
     // Attach to a route group
-    {
-        let mut api = app.map_group("/api");
+    app.group("/api", |api| {
         api.attach(Timeout { duration: Duration::from_secs(2) });
         api.map_get("/ping", || async { "pong" });
-    }
+    });
 
     app.run().await
 }

--- a/docs/ru/middleware-infrastructure/parameterized-middleware.md
+++ b/docs/ru/middleware-infrastructure/parameterized-middleware.md
@@ -107,11 +107,10 @@ async fn main() -> std::io::Result<()> {
         .attach(Timeout { duration: Duration::from_secs(1) });
 
     // Прикрепление к группе маршрутов
-    {
-        let mut api = app.map_group("/api");
+    app.group("/api", |api| {
         api.attach(Timeout { duration: Duration::from_secs(2) });
         api.map_get("/ping", || async { "pong" });
-    }
+    });
 
     app.run().await
 }

--- a/docs/ru/middleware-infrastructure/parameterized-middleware.md
+++ b/docs/ru/middleware-infrastructure/parameterized-middleware.md
@@ -1,0 +1,145 @@
+# Параметризованные Middleware
+
+Помимо встроенных middleware-замыканий, регистрируемых через [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) и [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with), Volga также поддерживает регистрацию middleware в виде повторно используемых настраиваемых типов через метод [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach).
+
+Такой подход удобен, когда middleware требует собственного состояния, конфигурации или должен использоваться повторно в нескольких приложениях.
+
+## Обзор
+
+Параметризованный middleware — это обычный Rust-тип (как правило, `struct`), реализующий трейт [`Middleware`](https://docs.rs/volga/latest/volga/middleware/trait.Middleware.html). Такой тип хранит всю необходимую конфигурацию и разделяемое состояние, а его метод [`call()`](https://docs.rs/volga/latest/volga/middleware/trait.Middleware.html#tymethod.call) содержит основную логику middleware.
+
+Это похоже на паттерны middleware в других экосистемах (например, слои Tower, middleware ASP.NET Core или классы Express.js).
+
+## Трейт `Middleware`
+
+Трейт определён следующим образом:
+```rust
+pub trait Middleware: Send + Sync + 'static {
+    fn call(
+        &self,
+        ctx: HttpContext,
+        next: NextFn,
+    ) -> impl Future<Output = HttpResult> + Send + 'static;
+}
+```
+
+Любой тип, реализующий этот трейт, можно передать в [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach).
+
+## Пример: Middleware `Timeout`
+
+Ниже приведён небольшой middleware, добавляющий искусственную задержку перед дальнейшей обработкой запроса. Длительность задержки настраивается при регистрации:
+```rust
+use std::time::Duration;
+use volga::{App, HttpResult, middleware::{HttpContext, NextFn, Middleware}};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // Регистрируем параметризованный middleware
+    app.attach(Timeout {
+        duration: Duration::from_secs(1),
+    });
+
+    app.map_get("/hello", || async { "Hello, World!" });
+
+    app.run().await
+}
+
+struct Timeout {
+    duration: Duration,
+}
+
+impl Middleware for Timeout {
+    fn call(&self, ctx: HttpContext, next: NextFn) -> impl Future<Output = HttpResult> + 'static {
+        let duration = self.duration;
+        async move {
+            tokio::time::sleep(duration).await;
+            next(ctx).await
+        }
+    }
+}
+```
+
+Структура `Timeout` хранит свою конфигурацию (`duration`) и реализует логику middleware внутри `call()`. Можно создать несколько экземпляров с разными значениями задержки или переиспользовать один экземпляр для нескольких маршрутов.
+
+## .wrap() и .attach()
+
+Оба метода регистрируют middleware, работающие с полным [`HttpContext`](https://docs.rs/volga/latest/volga/middleware/struct.HttpContext.html), но рассчитаны на разные сценарии:
+
+- [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) оптимизирован для коротких встроенных замыканий. Аннотации типов для `ctx` и `next` не требуются.
+- [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach) предназначен для повторно используемых параметризованных типов middleware — как правило, структур, реализующих трейт [`Middleware`](https://docs.rs/volga/latest/volga/middleware/trait.Middleware.html).
+
+::: tip
+Используйте [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) для быстрых встроенных middleware и [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach), когда нужно оформить middleware как именованный настраиваемый тип, пригодный для повторного использования.
+:::
+
+`attach()` также принимает замыкания, но в этом случае требуется указывать аннотации типов для аргументов:
+```rust
+use volga::{App, middleware::{HttpContext, NextFn}};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.attach(|ctx: HttpContext, next: NextFn| async move {
+        next(ctx).await
+    });
+
+    app.run().await
+}
+```
+
+## Регистрация на маршрутах и группах маршрутов
+
+Параметризованные middleware могут быть прикреплены не только ко всему приложению, но и к отдельным маршрутам и [группам маршрутов](../getting-started/route-groups.md):
+```rust
+use std::time::Duration;
+use volga::{App, HttpResult, middleware::{HttpContext, NextFn, Middleware}};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // Прикрепление к одному маршруту
+    app
+        .map_get("/hello", || async { "Hello, World!" })
+        .attach(Timeout { duration: Duration::from_secs(1) });
+
+    // Прикрепление к группе маршрутов
+    {
+        let mut api = app.map_group("/api");
+        api.attach(Timeout { duration: Duration::from_secs(2) });
+        api.map_get("/ping", || async { "pong" });
+    }
+
+    app.run().await
+}
+
+struct Timeout {
+    duration: Duration,
+}
+
+impl Middleware for Timeout {
+    fn call(&self, ctx: HttpContext, next: NextFn) -> impl Future<Output = HttpResult> + 'static {
+        let duration = self.duration;
+        async move {
+            tokio::time::sleep(duration).await;
+            next(ctx).await
+        }
+    }
+}
+```
+
+## Когда использовать параметризованные Middleware
+
+Выбирайте [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach) и отдельный тип, если:
+
+- Middleware требует **конфигурации** при регистрации (таймауты, лимиты, feature flags и т. п.).
+- Middleware должен быть **переиспользуемым** между проектами или крейтами.
+- Middleware хранит **разделяемое состояние**, счётчики или дескрипторы внешних систем.
+- Вы хотите **юнит-тестировать** middleware независимо от работающего приложения.
+
+Для простых разовых преобразований, как правило, лаконичнее оставить логику встроенной через [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) или [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with).
+
+Встроенные возможности, такие как [CORS](./cors.md), [аутентификация](../security-access/auth.md) и [ограничение частоты запросов](./rate-limiting.md), сами реализованы как параметризованные middleware поверх [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach).


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for Volga's parameterized middleware feature, explaining how to create reusable, configurable middleware types using the `attach()` method.

## Changes
- **New documentation pages**: Added `parameterized-middleware.md` in both English (`docs/en/`) and Russian (`docs/ru/`) with complete coverage of:
  - Overview of parameterized middleware and the `Middleware` trait
  - Practical example of a `Timeout` middleware with configurable duration
  - Comparison between `wrap()` and `attach()` methods
  - How to register middleware on individual routes and route groups
  - Guidelines for when to prefer parameterized middleware over inline closures

- **Updated navigation**: Modified `docs/.vuepress/config.js` to include the new documentation page in the "Middleware & Infrastructure" section for both English and Russian documentation sites

## Implementation Details
The documentation includes:
- Clear trait definition showing the `Middleware` trait signature
- Runnable code examples demonstrating practical usage patterns
- Guidance on configuration, reusability, and testing benefits
- Cross-references to related features (CORS, authentication, rate limiting) that are implemented as parameterized middleware
- Tips distinguishing when to use `wrap()` for simple inline middleware vs `attach()` for structured, reusable types

https://claude.ai/code/session_01GJabn1LVtE8ThVDeDzYBba