### PR TITLE
Add documentation for other middleware trait variants

### DIFF
--- a/docs/en/middleware-infrastructure/parameterized-middleware.md
+++ b/docs/en/middleware-infrastructure/parameterized-middleware.md
@@ -142,3 +142,32 @@ Reach for [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#me
 For simple, one-off transformations, keeping the logic inline with [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) or [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with) is typically more concise.
 
 Built-in features such as [CORS](./cors.md), [authentication](../security-access/auth.md) and [rate limiting](./rate-limiting.md) are themselves implemented as parameterized middleware on top of [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach).
+
+## Other Middleware Variants
+
+The same parameterized approach works for the other middleware traits as well. Besides [`Middleware`](https://docs.rs/volga/latest/volga/middleware/handler/trait.Middleware.html), you can implement [`Filter`](https://docs.rs/volga/latest/volga/middleware/handler/trait.Filter.html), [`TapReq`](https://docs.rs/volga/latest/volga/middleware/handler/trait.TapReq.html), [`MapOk`](https://docs.rs/volga/latest/volga/middleware/handler/trait.MapOk.html), [`MapErr`](https://docs.rs/volga/latest/volga/http/endpoints/handlers/trait.MapErr.html), and [`With`](https://docs.rs/volga/latest/volga/middleware/handler/trait.With.html) on your own types. They are registered using the same methods as their closure counterparts — [`filter()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.filter), [`tap_req()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.tap_req), [`map_ok()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_ok), [`map_err()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_err), and [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with) respectively. For example, a reusable parameterized filter:
+
+```rust
+use volga::{App, Path, http::FilterResult, middleware::handler::Filter};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_get("/sum/{x}/{y}", |x: i32, y: i32| async move { x + y })
+        .filter(PositiveOnly);
+
+    app.run().await
+}
+
+#[derive(Clone)]
+struct PositiveOnly;
+
+impl Filter<Path<(i32, i32)>> for PositiveOnly {
+    type Output = bool;
+
+    async fn filter(&self, Path((x, y)): Path<(i32, i32)>) -> bool {
+        x >= 0 && y >= 0
+    }
+}
+```

--- a/docs/ru/middleware-infrastructure/parameterized-middleware.md
+++ b/docs/ru/middleware-infrastructure/parameterized-middleware.md
@@ -142,3 +142,32 @@ impl Middleware for Timeout {
 Для простых разовых преобразований, как правило, лаконичнее оставить логику встроенной через [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wrap) или [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with).
 
 Встроенные возможности, такие как [CORS](./cors.md), [аутентификация](../security-access/auth.md) и [ограничение частоты запросов](./rate-limiting.md), сами реализованы как параметризованные middleware поверх [`attach()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.attach).
+
+## Другие варианты Middleware
+
+Тот же параметризованный подход работает и для остальных middleware-трейтов. Помимо [`Middleware`](https://docs.rs/volga/latest/volga/middleware/handler/trait.Middleware.html), вы можете реализовать [`Filter`](https://docs.rs/volga/latest/volga/middleware/handler/trait.Filter.html), [`TapReq`](https://docs.rs/volga/latest/volga/middleware/handler/trait.TapReq.html), [`MapOk`](https://docs.rs/volga/latest/volga/middleware/handler/trait.MapOk.html), [`MapErr`](https://docs.rs/volga/latest/volga/http/endpoints/handlers/trait.MapErr.html) и [`With`](https://docs.rs/volga/latest/volga/middleware/handler/trait.With.html) на собственных типах. Они регистрируются теми же методами, что и их аналоги-замыкания — [`filter()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.filter), [`tap_req()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.tap_req), [`map_ok()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_ok), [`map_err()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_err) и [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with) соответственно. Например, переиспользуемый параметризованный фильтр:
+
+```rust
+use volga::{App, Path, http::FilterResult, middleware::handler::Filter};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_get("/sum/{x}/{y}", |x: i32, y: i32| async move { x + y })
+        .filter(PositiveOnly);
+
+    app.run().await
+}
+
+#[derive(Clone)]
+struct PositiveOnly;
+
+impl Filter<Path<(i32, i32)>> for PositiveOnly {
+    type Output = bool;
+
+    async fn filter(&self, Path((x, y)): Path<(i32, i32)>) -> bool {
+        x >= 0 && y >= 0
+    }
+}
+```


### PR DESCRIPTION
## Summary
Added a new section to the parameterized middleware documentation explaining how to implement and use other middleware traits beyond the basic `Middleware` trait. This documentation is now available in both English and Russian versions.

## Key Changes
- Added "Other Middleware Variants" section to both `docs/en/middleware-infrastructure/parameterized-middleware.md` and `docs/ru/middleware-infrastructure/parameterized-middleware.md`
- Documented the parameterized approach for implementing `Filter`, `TapReq`, `MapOk`, `MapErr`, and `With` traits on custom types
- Provided a practical example showing how to create a reusable `PositiveOnly` filter that validates path parameters
- Clarified the registration methods for each trait variant (`filter()`, `tap_req()`, `map_ok()`, `map_err()`, `with()`)

## Notable Details
- The example demonstrates a concrete use case: filtering requests to only accept non-negative integer parameters
- The documentation maintains consistency between English and Russian versions with identical code examples
- The new section builds naturally on the existing explanation of parameterized middleware using the `Middleware` trait

https://claude.ai/code/session_01K8jHXgoffmu9kWyA93Kb6r