### PR TITLE
Add OAuth 2.1 & OpenID Connect documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -68,7 +68,7 @@ export default defineUserConfig({
           {
             text: 'Security & Access',
             prefix: '/en/security-access/',
-            children: ['auth'],
+            children: ['auth', 'oauth', 'oauth-client'],
           },
           {
             text: 'Reliability & Observability',
@@ -126,7 +126,7 @@ export default defineUserConfig({
           {
             text: 'Безопасность и доступ',
             prefix: '/ru/security-access/',
-            children: ['auth'],
+            children: ['auth', 'oauth', 'oauth-client'],
           },
           {
             text: 'Надежность и наблюдаемость',

--- a/docs/en/security-access/auth.md
+++ b/docs/en/security-access/auth.md
@@ -204,6 +204,20 @@ To ensure proper JWT functionality, you must use the same `JWT_SECRET` both when
 This secret is used to sign the token during generation and to verify the signature during validation. If these values differ - the token will be rejected as invalid.
 :::
 
+### Validating Tokens Against an OAuth 2.1 / OIDC Issuer
+
+Rather than configuring a static key, a resource server can validate bearer tokens against an OAuth 2.1 / OIDC issuer's published keys — no shared secret required. Describe the issuer with [`with_oauth(...)`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth) and opt in with [`use_oauth()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth):
+
+```rust
+let mut app = App::new()
+    .with_bearer_auth(|auth| auth.with_aud(["https://api.example.com"]))
+    .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"));
+
+app.use_oauth();
+```
+
+See the [OAuth 2.1 & OpenID Connect](/en/security-access/oauth.html) page for the full flow (issuer-based validation, key rotation and metadata serving) and the [OAuth 2.1 Client](/en/security-access/oauth-client.html) page for driving the Authorization Code + PKCE flow.
+
 ## Defining Claims
 
 The `jwt-auth-full` feature enables the [`Claims`](https://docs.rs/volga/latest/volga/auth/derive.Claims.html) derive macro for defining JWT claims. Alternatively, you can define claims using:

--- a/docs/en/security-access/oauth-client.md
+++ b/docs/en/security-access/oauth-client.md
@@ -29,21 +29,21 @@ At least one of the two must be enabled.
 [`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) resolves the well-known discovery URLs, fetches the documents over HTTPS and validates each against the identifier it was requested for (RFC 8414 §3.3 / RFC 9728 §3.3):
 
 ```rust
-use volga_oauth_client::DiscoveryClient;
+use volga_oauth_client::{ClientError, DiscoveryClient};
 
-# async fn discover() -> Result<(), volga_oauth_client::ClientError> {
-let client = DiscoveryClient::new();
+async fn discover() -> Result<(), ClientError> {
+    let client = DiscoveryClient::new();
 
-// straight from an issuer identifier (RFC 8414, or the OIDC path):
-let server = client.fetch_server_metadata("https://auth.example.com").await?;
+    // straight from an issuer identifier (RFC 8414, or the OIDC path):
+    let server = client.fetch_server_metadata("https://auth.example.com").await?;
 
-// or start from the resource and follow it to its authorization server:
-let resource = client.fetch_resource_metadata("https://api.example.com").await?;
-let server = client.discover_authorization_server(&resource).await?;
+    // or start from the resource and follow it to its authorization server:
+    let resource = client.fetch_resource_metadata("https://api.example.com").await?;
+    let server = client.discover_authorization_server(&resource).await?;
 
-assert!(server.token_endpoint.is_some());
-# Ok(())
-# }
+    assert!(server.token_endpoint.is_some());
+    Ok(())
+}
 ```
 
 * [`fetch_server_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_server_metadata) / [`fetch_oidc_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_oidc_metadata) — the same document shape at the RFC 8414 and OIDC Discovery paths.
@@ -141,26 +141,28 @@ The key is chosen by the application — typically a user or session identifier,
 [`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) submits [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientMetadata.html) to a server's registration endpoint (RFC 7591) and returns the issued credentials. [`OAuthClient::from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration) adopts them into a ready-to-use client:
 
 ```rust
-use volga_oauth_client::{ClientMetadata, DiscoveryClient, OAuthClient, RegistrationClient};
+use volga_oauth_client::{
+    ClientError, ClientMetadata, DiscoveryClient, OAuthClient, RegistrationClient,
+};
 
-# async fn register() -> Result<(), volga_oauth_client::ClientError> {
-let metadata = DiscoveryClient::new()
-    .fetch_server_metadata("https://auth.example.com")
-    .await?;
+async fn register() -> Result<(), ClientError> {
+    let metadata = DiscoveryClient::new()
+        .fetch_server_metadata("https://auth.example.com")
+        .await?;
 
-let registered = RegistrationClient::new()
-    .register(
-        &metadata,
-        &ClientMetadata::new()
-            .with_redirect_uris(["https://app.example.com/callback"])
-            .with_client_name("My App"),
-    )
-    .await?;
+    let registered = RegistrationClient::new()
+        .register(
+            &metadata,
+            &ClientMetadata::new()
+                .with_redirect_uris(["https://app.example.com/callback"])
+                .with_client_name("My App"),
+        )
+        .await?;
 
-// ready-to-use client under the issued credentials
-let client = OAuthClient::from_registration(&registered)?;
-# Ok(())
-# }
+    // ready-to-use client under the issued credentials
+    let client = OAuthClient::from_registration(&registered)?;
+    Ok(())
+}
 ```
 
 For servers that do not allow open registration, attach an initial access token with [`with_initial_access_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html#method.with_initial_access_token).

--- a/docs/en/security-access/oauth-client.md
+++ b/docs/en/security-access/oauth-client.md
@@ -1,0 +1,191 @@
+# OAuth 2.1 Client
+
+`volga-oauth-client` is an OAuth 2.1 / OpenID Connect client built on the shared protocol types from `volga-oauth-core`. It is **independent of the `volga` server crate** — usable from any Tokio application (a CLI, a background worker, or a volga web app driving a login flow).
+
+It provides three clients, all sharing the transport policy of [`ClientConfig`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientConfig.html) and the error model of [`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html):
+
+* [`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) — fetches Authorization Server Metadata (RFC 8414), Protected Resource Metadata (RFC 9728) and the OpenID Connect provider configuration.
+* [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) — the Authorization Code flow with mandatory PKCE, refresh tokens and resource indicators, plus token persistence.
+* [`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) — Dynamic Client Registration (RFC 7591).
+
+## Dependencies
+
+```toml
+[dependencies]
+volga-oauth-client = { version = "..." }
+```
+
+### Feature flags
+
+| Flag | What it enables |
+|---|---|
+| `http1` (default) | HTTP/1.1 via hyper |
+| `http2` | HTTP/2 via hyper; negotiated through TLS ALPN when combined with `http1`, used exclusively (prior knowledge over plaintext) without it |
+
+At least one of the two must be enabled.
+
+## Discovery
+
+[`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) resolves the well-known discovery URLs, fetches the documents over HTTPS and validates each against the identifier it was requested for (RFC 8414 §3.3 / RFC 9728 §3.3):
+
+```rust
+use volga_oauth_client::DiscoveryClient;
+
+# async fn discover() -> Result<(), volga_oauth_client::ClientError> {
+let client = DiscoveryClient::new();
+
+// straight from an issuer identifier (RFC 8414, or the OIDC path):
+let server = client.fetch_server_metadata("https://auth.example.com").await?;
+
+// or start from the resource and follow it to its authorization server:
+let resource = client.fetch_resource_metadata("https://api.example.com").await?;
+let server = client.discover_authorization_server(&resource).await?;
+
+assert!(server.token_endpoint.is_some());
+# Ok(())
+# }
+```
+
+* [`fetch_server_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_server_metadata) / [`fetch_oidc_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_oidc_metadata) — the same document shape at the RFC 8414 and OIDC Discovery paths.
+* [`fetch_resource_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_resource_metadata) / [`fetch_resource_metadata_from_url`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_resource_metadata_from_url) — the latter takes the `resource_metadata` URL straight from a `WWW-Authenticate` challenge.
+* [`discover_authorization_server`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.discover_authorization_server) — takes the first advertised authorization server and fetches its metadata, falling back from the RFC 8414 path to the OIDC path automatically.
+* [`fetch_jwks`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_jwks) / [`fetch_jwks_from_url`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_jwks_from_url) — the issuer's JSON Web Key Set as raw JSON.
+
+::: tip
+Attach a [`MetadataCache`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.MetadataCache.html) with [`with_cache(...)`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.with_cache) to reuse your existing storage; discovery documents rarely change. JWKS fetches deliberately bypass the cache in both directions — signing keys rotate, so freshness policy belongs to you.
+:::
+
+## Authorization Code + PKCE
+
+[`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) drives the OAuth 2.1 Authorization Code flow. PKCE (S256) is generated and applied automatically — it is the protection OAuth 2.1 prescribes for public clients.
+
+```rust
+use std::sync::Arc;
+use volga_oauth_client::{ClientError, DiscoveryClient, InMemoryTokenStore, OAuthClient};
+
+async fn authorize() -> Result<(), ClientError> {
+    let metadata = DiscoveryClient::new()
+        .fetch_server_metadata("https://auth.example.com")
+        .await?;
+
+    let client = OAuthClient::new("my-client")
+        .with_redirect_uri("https://app.example.com/callback")
+        .with_token_store(Arc::new(InMemoryTokenStore::new()));
+
+    // 1. build the authorization request (state and PKCE are generated)
+    let auth = client
+        .authorization_request(&metadata)
+        .with_scopes(["read"])
+        .with_resource("https://api.example.com")
+        .build()?;
+
+    // 2. send the user to `auth.url`; then, in the redirect callback:
+    let (code, state) = ("code", "state");
+    assert!(auth.matches_state(state)); // always verify — CSRF protection
+
+    // 3. exchange the code for tokens (the PKCE verifier goes along)
+    let tokens = client.exchange_code(&metadata, code, &auth).await?;
+    client.store_tokens("alice", &tokens);
+
+    // 4. later — served from the store, transparently refreshed when stale:
+    let tokens = client.token("alice", &metadata).await?;
+    Ok(())
+}
+```
+
+The [`AuthorizationRequest`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html) that [`build()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.build) returns holds the `url` to redirect to, the `state` to check on the callback and the PKCE pair. It is `Serialize`/`Deserialize`, so a web application can stash it in the session between the redirect and the callback.
+
+The request builder accepts [`with_scopes`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.with_scopes), [`with_resource`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.with_resource) (RFC 8707, repeatable), [`with_state`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.with_state) (override the generated value) and [`with_param`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.with_param) (e.g. the OIDC `nonce` or `prompt`).
+
+::: warning
+Always verify the callback `state` with [`matches_state`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.matches_state) **before** exchanging the code — it is your CSRF defence.
+:::
+
+### Transparent refresh
+
+[`token(key, &metadata)`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.token) reads the stored tokens and refreshes a stale access token behind the scenes. It returns `Ok(None)` when interactive authorization is required — nothing is stored, the entry has no refresh token, or the server rejected the refresh token (`invalid_grant`); in the latter cases the dead entry is removed from the store. You can also refresh explicitly with [`refresh`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.refresh).
+
+### Confidential clients
+
+Without a secret the client acts as a **public client** (PKCE is the protection). Attach a secret to authenticate to the token endpoint:
+
+```rust
+use volga_oauth_client::{ClientAuthMethod, OAuthClient};
+
+let client = OAuthClient::new("my-client")
+    .with_secret("s3cret")
+    // `client_secret_basic` (default) or `client_secret_post`
+    .with_auth_method(ClientAuthMethod::Post);
+```
+
+## Token Store
+
+Persistence goes through the [`TokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.TokenStore.html) trait. [`InMemoryTokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.InMemoryTokenStore.html) is the built-in process-local implementation — suitable for CLIs, tests and single-instance services; anything durable (a database, an encrypted file, an OS keychain) is one trait impl away.
+
+```rust
+use volga_oauth_client::{TokenSet, TokenStore};
+
+struct MyStore;
+
+impl TokenStore for MyStore {
+    fn get(&self, key: &str) -> Option<TokenSet> { /* ... */ None }
+    fn put(&self, key: &str, tokens: &TokenSet) { /* ... */ }
+    fn remove(&self, key: &str) { /* ... */ }
+}
+```
+
+The key is chosen by the application — typically a user or session identifier, combined with the resource when one client serves several audiences. A [`TokenSet`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html) carries the access token, an optional refresh token, the granted scope, the OIDC `id_token` (passed through, not validated) and an absolute `expires_at`; tokens are redacted from its `Debug` output.
+
+## Dynamic Client Registration
+
+[`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) submits [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientMetadata.html) to a server's registration endpoint (RFC 7591) and returns the issued credentials. [`OAuthClient::from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration) adopts them into a ready-to-use client:
+
+```rust
+use volga_oauth_client::{ClientMetadata, DiscoveryClient, OAuthClient, RegistrationClient};
+
+# async fn register() -> Result<(), volga_oauth_client::ClientError> {
+let metadata = DiscoveryClient::new()
+    .fetch_server_metadata("https://auth.example.com")
+    .await?;
+
+let registered = RegistrationClient::new()
+    .register(
+        &metadata,
+        &ClientMetadata::new()
+            .with_redirect_uris(["https://app.example.com/callback"])
+            .with_client_name("My App"),
+    )
+    .await?;
+
+// ready-to-use client under the issued credentials
+let client = OAuthClient::from_registration(&registered)?;
+# Ok(())
+# }
+```
+
+For servers that do not allow open registration, attach an initial access token with [`with_initial_access_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html#method.with_initial_access_token).
+
+::: info
+The RFC 7592 management protocol (reading, updating and deleting a registration) is not implemented, but the `registration_access_token` / `registration_client_uri` pair from the response is surfaced for applications that need it.
+:::
+
+## Transport Policy & Errors
+
+[`ClientConfig`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientConfig.html) carries the policy shared by every client operation — HTTPS enforcement, per-request timeouts and redirect limits. The defaults are safe for production; the most common override is disabling HTTPS for a local development server:
+
+```rust
+use std::time::Duration;
+use volga_oauth_client::{ClientConfig, OAuthClient};
+
+let config = ClientConfig::new()
+    .require_https(false)              // local development only
+    .with_timeout(Duration::from_secs(5))
+    .with_max_redirects(0);
+
+let client = OAuthClient::new("my-client").with_config(config);
+```
+
+[`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) separates a parsed OAuth error response (`Protocol`, carrying the RFC 6749 §5.2 [`OAuthError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthError.html)) from transport, decode, insecure-URL and validation failures — so you can distinguish "the server said `invalid_grant`" from "the connection dropped".
+
+## Examples
+* [OAuth Flow](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_flow/src/main.rs) — a full discovery → authorization → code exchange → protected call flow driven by `volga-oauth-client`.

--- a/docs/en/security-access/oauth-client.md
+++ b/docs/en/security-access/oauth-client.md
@@ -79,9 +79,16 @@ async fn authorize() -> Result<(), ClientError> {
         .with_resource("https://api.example.com")
         .build()?;
 
-    // 2. send the user to `auth.url`; then, in the redirect callback:
-    let (code, state) = ("code", "state");
-    assert!(auth.matches_state(state)); // always verify — CSRF protection
+    // 2. send the user to `auth.url`. The provider redirects back to your
+    //    callback with the real `code` and `state` query parameters — read
+    //    them there. (This snippet reuses the generated `auth.state` so the
+    //    check below holds on the happy path.)
+    let (code, state) = ("the-authorization-code", auth.state.as_str());
+
+    // always verify the callback state before exchanging — CSRF protection
+    if !auth.matches_state(state) {
+        return Ok(()); // reject — possible CSRF
+    }
 
     // 3. exchange the code for tokens (the PKCE verifier goes along)
     let tokens = client.exchange_code(&metadata, code, &auth).await?;

--- a/docs/en/security-access/oauth.md
+++ b/docs/en/security-access/oauth.md
@@ -1,0 +1,210 @@
+# OAuth 2.1 & OpenID Connect
+
+Volga ships a full OAuth 2.1 / OpenID Connect foundation on top of its [Bearer Token authentication](/en/security-access/auth.html). It lets you build **resource servers** that validate tokens against an OAuth 2.1 / OIDC issuer's published keys — with no shared secret — and **serve the discovery metadata documents** clients need to start a flow.
+
+The protocol-level types (error models, metadata documents, the `WWW-Authenticate` challenge builder, well-known URL derivation) live under [`volga::auth::oauth`](https://docs.rs/volga/latest/volga/auth/oauth/index.html) and are shared with the standalone [OAuth client](/en/security-access/oauth-client.html).
+
+## Feature flags
+
+| Feature | What it enables |
+|---|---|
+| `oauth` | OAuth 2.1 / OIDC foundation types at `volga::auth::oauth` and metadata serving (implied by `jwt-auth`). |
+| `oauth-client` | Issuer-based bearer validation — `App::with_oauth` / `App::use_oauth`. Implies `jwt-auth`. |
+
+```toml
+[dependencies]
+volga = { version = "...", features = ["oauth-client"] }
+```
+
+## Validating Tokens Against an Issuer
+
+Instead of configuring a static [`DecodingKey`](https://docs.rs/volga/latest/volga/auth/decoding_key/struct.DecodingKey.html), you can point bearer authentication at an OAuth 2.1 / OIDC issuer. Volga fetches the issuer's server metadata (RFC 8414, with an OpenID Connect Discovery fallback) and the JSON Web Key Set it advertises, then validates incoming JWTs keyed by each token's `kid`.
+
+Describe the issuer with [`with_oauth(...)`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth) and activate it explicitly with [`use_oauth()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth):
+
+```rust
+use serde::Deserialize;
+use volga::{
+    App, ok,
+    auth::{AuthClaims, roles},
+};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new()
+        // audience, expiry and the other token checks stay here
+        .with_bearer_auth(|auth| auth.with_aud(["https://api.example.com"]))
+        // the keys and the `iss` constraint come from the issuer
+        .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"));
+
+    // explicit opt-in — nothing validates against the issuer until this call
+    app.use_oauth();
+
+    app.map_get("/protected", protected)
+        .authorize::<Claims>(roles(["admin"]));
+
+    app.run().await
+}
+
+async fn protected() -> &'static str {
+    "Hello from the protected route!"
+}
+
+#[derive(Clone, Deserialize)]
+struct Claims {
+    role: String,
+}
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> {
+        Some(&self.role)
+    }
+}
+```
+
+With issuer-based validation no static decoding key is required — the keys are resolved at runtime. Everything else (`aud`, expiry, scopes and roles) keeps coming from [`with_bearer_auth`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_bearer_auth).
+
+::: info
+The `iss` claim is constrained to the configured issuer automatically and made **required** — tokens omitting it, or carrying a different issuer, are rejected.
+:::
+
+### Key lifecycle
+
+Keys are fetched lazily on the first request and cached, so token validation costs no network round-trip in the common case. The cache maintains itself:
+
+* A token with an **unknown `kid`** triggers a refresh (key rotation), rate-limited by [`with_refresh_cooldown`](https://docs.rs/volga/latest/volga/auth/struct.OAuthConfig.html#method.with_refresh_cooldown) (default 60 s); concurrent misses share a single refresh.
+* Known `kid`s are **re-checked** with the issuer once the cached set is older than [`with_max_key_age`](https://docs.rs/volga/latest/volga/auth/struct.OAuthConfig.html#method.with_max_key_age) (default 15 minutes), so a revoked or re-keyed `kid` stops validating without a restart.
+* While the issuer is **unreachable** and keys were already loaded, the last known set keeps serving — an issuer outage does not take token validation down with it. When no keys have ever loaded, protected routes answer `503` (a server-side problem) rather than blaming the token.
+
+### Configuration
+
+The issuer is mandatory; everything else has production-safe defaults.
+
+```rust
+use std::time::Duration;
+use volga::App;
+
+let app = App::new()
+    .with_bearer_auth(|auth| auth.with_aud(["https://api.example.com"]))
+    .with_oauth(|oauth| oauth
+        .with_issuer("https://auth.example.com")
+        .with_refresh_cooldown(Duration::from_secs(30))
+        .with_max_key_age(Duration::from_secs(600))
+        // discovery / JWKS transport policy
+        .with_client_config(|client| client.require_https(true)));
+```
+
+For a local development issuer served over plain HTTP, relax the transport policy:
+
+```rust
+let app = App::new()
+    .with_oauth(|oauth| oauth
+        .with_issuer("http://127.0.0.1:5000")
+        .with_client_config(|client| client.require_https(false)));
+```
+
+With the `config` feature the same knobs can be described in the `[oauth.client]` section of the configuration file — fields present in the file override the builder calls, unknown keys fail startup, and activation still requires the explicit `App::use_oauth()` call in code:
+
+```toml
+[oauth.client]
+issuer = "https://auth.example.com"
+refresh_cooldown_secs = 60   # optional
+max_key_age_secs = 900       # optional
+require_https = true         # optional
+timeout_secs = 30            # optional
+max_redirects = 5            # optional
+```
+
+## Serving Metadata Documents
+
+A resource server tells clients where to authenticate; an authorization server publishes its endpoints and keys. Volga serves both discovery documents from your application.
+
+### Protected Resource Metadata (RFC 9728)
+
+Configure it with [`with_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth_resource_metadata) (or [`set_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.set_oauth_resource_metadata) for the whole value, including the `&str` identifier shorthand) and serve it with [`use_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth_resource_metadata):
+
+```rust
+let mut app = App::new()
+    .with_oauth_resource_metadata(|metadata| metadata
+        .with_resource("https://api.example.com")
+        .with_authorization_servers(["https://auth.example.com"])
+        .with_scopes(["read", "write"])
+        .with_bearer_methods(["header"]));
+
+// GET /.well-known/oauth-protected-resource
+app.use_oauth_resource_metadata();
+```
+
+When bearer authentication is configured, the derived metadata URL is advertised automatically in `WWW-Authenticate` challenges (RFC 9728 §5.1), so an unauthenticated client can discover where to authenticate and start a flow.
+
+### Authorization Server Metadata (RFC 8414) & OIDC Discovery
+
+Applications that are themselves an authorization server publish their endpoints via [`with_oauth_server_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth_server_metadata) and serve the document at one or both discovery paths:
+
+```rust
+let mut app = App::new()
+    .with_oauth_server_metadata(|metadata| metadata
+        .with_issuer("https://auth.example.com")
+        .with_authorization_endpoint("https://auth.example.com/authorize")
+        .with_token_endpoint("https://auth.example.com/token")
+        .with_jwks_uri("https://auth.example.com/jwks"));
+
+// authorization servers commonly publish the same document at both paths:
+app.use_oauth_server_metadata()  // GET /.well-known/oauth-authorization-server
+   .use_oidc_metadata();         // GET /.well-known/openid-configuration
+```
+
+::: tip
+The server-metadata closure is seeded with the OAuth 2.1 prefills `response_types_supported = ["code"]` and `grant_types_supported = ["authorization_code"]`. OIDC-specific fields required by a compliant provider document (`subject_types_supported`, `id_token_signing_alg_values_supported`, `userinfo_endpoint`, …) can be supplied through [`with_additional_field(...)`](https://docs.rs/volga/latest/volga/auth/oauth/struct.AuthorizationServerMetadata.html#method.with_additional_field).
+:::
+
+Both documents can also come from the `[oauth.resource]` / `[oauth.server]` sections of the configuration file (the `config` feature); the file overrides prior builder calls. The `set_*` shorthand configures a minimal document from the identifier alone:
+
+```rust
+let mut app = App::new()
+    .set_oauth_resource_metadata("https://api.example.com")
+    .set_oauth_server_metadata("https://auth.example.com");
+
+app.use_oauth_resource_metadata();
+app.use_oauth_server_metadata().use_oidc_metadata();
+```
+
+## The Full Flow
+
+Putting the pieces together, a resource server needs only a handful of lines — token validation is wired straight to the issuer's published keys, with no secret configured anywhere:
+
+```rust
+use volga::{App, auth::{AuthClaims, roles}, ok};
+use serde::Deserialize;
+
+#[derive(Clone, Deserialize)]
+struct Claims { role: String }
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> { Some(&self.role) }
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new()
+        .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"))
+        // advertised in WWW-Authenticate challenges
+        .with_oauth_resource_metadata(|m| m
+            .with_resource("https://api.example.com")
+            .with_authorization_servers(["https://auth.example.com"]));
+
+    app.use_oauth();
+    app.use_oauth_resource_metadata();
+
+    app.map_get("/protected", || async { ok!("Hello from the protected route!") })
+        .authorize::<Claims>(roles(["admin"]));
+
+    app.run().await
+}
+```
+
+The client side of the same flow — discovery, the Authorization Code + PKCE exchange and calling the protected route — is covered on the [OAuth 2.1 Client](/en/security-access/oauth-client.html) page.
+
+## Examples
+* [OAuth Flow](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_flow/src/main.rs) — a complete Authorization Code + PKCE flow between an authorization server, a resource server and a client, in one process.
+* [OAuth Metadata](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_metadata/src/main.rs) — serving the RFC 8414 / RFC 9728 / OIDC discovery documents.

--- a/docs/ru/security-access/auth.md
+++ b/docs/ru/security-access/auth.md
@@ -203,6 +203,20 @@ struct Claims {
 Этот секрет используется для подписания токена на этапе генерации и проверки подписи на этапе валидации. Если секреты отличаются - токен будет отклонён как недействительный.
 :::
 
+### Валидация токенов по OAuth 2.1 / OIDC-эмитенту
+
+Вместо настройки статического ключа сервер ресурсов может валидировать Bearer-токены по опубликованным ключам OAuth 2.1 / OIDC-эмитента — без общего секрета. Опишите эмитента через [`with_oauth(...)`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth) и подключите через [`use_oauth()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth):
+
+```rust
+let mut app = App::new()
+    .with_bearer_auth(|auth| auth.with_aud(["https://api.example.com"]))
+    .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"));
+
+app.use_oauth();
+```
+
+Полный флоу (валидация по эмитенту, ротация ключей и отдача метаданных) описан на странице [OAuth 2.1 и OpenID Connect](/ru/security-access/oauth.html), а запуск флоу Authorization Code + PKCE — на странице [OAuth 2.1 Клиент](/ru/security-access/oauth-client.html).
+
 ## Определение структуры Claims
 
 Для удобства `jwt-auth-full` включает derive-макрос [`Claims`](https://docs.rs/volga/latest/volga/auth/derive.Claims.html) для объявления структуры claim'ов. Но вы также можете использовать альтернативные способы:

--- a/docs/ru/security-access/oauth-client.md
+++ b/docs/ru/security-access/oauth-client.md
@@ -79,9 +79,16 @@ async fn authorize() -> Result<(), ClientError> {
         .with_resource("https://api.example.com")
         .build()?;
 
-    // 2. отправляем пользователя на `auth.url`; затем в callback-редиректе:
-    let (code, state) = ("code", "state");
-    assert!(auth.matches_state(state)); // всегда проверяйте — защита от CSRF
+    // 2. отправляем пользователя на `auth.url`. Провайдер редиректит обратно
+    //    на ваш callback с настоящими query-параметрами `code` и `state` —
+    //    их и читаем там. (В этом примере переиспользуется сгенерированный
+    //    `auth.state`, чтобы проверка ниже проходила на «счастливом пути».)
+    let (code, state) = ("the-authorization-code", auth.state.as_str());
+
+    // всегда проверяйте state из callback до обмена — защита от CSRF
+    if !auth.matches_state(state) {
+        return Ok(()); // отклоняем — возможен CSRF
+    }
 
     // 3. обмениваем код на токены (verifier PKCE идёт вместе с запросом)
     let tokens = client.exchange_code(&metadata, code, &auth).await?;

--- a/docs/ru/security-access/oauth-client.md
+++ b/docs/ru/security-access/oauth-client.md
@@ -1,0 +1,191 @@
+# OAuth 2.1 Клиент
+
+`volga-oauth-client` — это клиент OAuth 2.1 / OpenID Connect, построенный на общих типах протокола из `volga-oauth-core`. Он **не зависит от серверного крейта `volga`** — его можно использовать в любом Tokio-приложении (CLI, фоновом воркере или веб-приложении на Волге, реализующем флоу входа).
+
+Он предоставляет три клиента, разделяющих транспортную политику [`ClientConfig`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientConfig.html) и модель ошибок [`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html):
+
+* [`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) — загружает Authorization Server Metadata (RFC 8414), Protected Resource Metadata (RFC 9728) и конфигурацию провайдера OpenID Connect.
+* [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) — флоу Authorization Code с обязательным PKCE, refresh-токенами и индикаторами ресурсов, плюс сохранение токенов.
+* [`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) — динамическую регистрацию клиентов (RFC 7591).
+
+## Зависимости
+
+```toml
+[dependencies]
+volga-oauth-client = { version = "..." }
+```
+
+### Feature-флаги
+
+| Флаг | Что включает |
+|---|---|
+| `http1` (по-умолчанию) | HTTP/1.1 через hyper |
+| `http2` | HTTP/2 через hyper; согласуется через TLS ALPN при совместном использовании с `http1`, либо используется эксклюзивно (prior knowledge поверх plaintext) без него |
+
+Как минимум один из двух должен быть включён.
+
+## Discovery
+
+[`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) разрешает well-known discovery-URL, загружает документы по HTTPS и проверяет каждый на соответствие идентификатору, для которого он был запрошен (RFC 8414 §3.3 / RFC 9728 §3.3):
+
+```rust
+use volga_oauth_client::DiscoveryClient;
+
+# async fn discover() -> Result<(), volga_oauth_client::ClientError> {
+let client = DiscoveryClient::new();
+
+// напрямую по идентификатору эмитента (RFC 8414 или путь OIDC):
+let server = client.fetch_server_metadata("https://auth.example.com").await?;
+
+// или начиная с ресурса и следуя к его серверу авторизации:
+let resource = client.fetch_resource_metadata("https://api.example.com").await?;
+let server = client.discover_authorization_server(&resource).await?;
+
+assert!(server.token_endpoint.is_some());
+# Ok(())
+# }
+```
+
+* [`fetch_server_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_server_metadata) / [`fetch_oidc_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_oidc_metadata) — один и тот же вид документа по путям RFC 8414 и OIDC Discovery.
+* [`fetch_resource_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_resource_metadata) / [`fetch_resource_metadata_from_url`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_resource_metadata_from_url) — второй берёт URL `resource_metadata` прямо из заголовка `WWW-Authenticate`.
+* [`discover_authorization_server`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.discover_authorization_server) — берёт первый объявленный сервер авторизации и загружает его метаданные, автоматически откатываясь с пути RFC 8414 на путь OIDC.
+* [`fetch_jwks`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_jwks) / [`fetch_jwks_from_url`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_jwks_from_url) — набор ключей JSON Web Key Set эмитента в виде сырого JSON.
+
+::: tip
+Подключите [`MetadataCache`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.MetadataCache.html) через [`with_cache(...)`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.with_cache), чтобы переиспользовать имеющееся хранилище; discovery-документы меняются редко. Загрузки JWKS намеренно обходят кэш в обе стороны — ключи подписи ротируются, поэтому политика свежести остаётся за вами.
+:::
+
+## Authorization Code + PKCE
+
+[`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) реализует флоу OAuth 2.1 Authorization Code. PKCE (S256) генерируется и применяется автоматически — это защита, которую OAuth 2.1 предписывает для публичных клиентов.
+
+```rust
+use std::sync::Arc;
+use volga_oauth_client::{ClientError, DiscoveryClient, InMemoryTokenStore, OAuthClient};
+
+async fn authorize() -> Result<(), ClientError> {
+    let metadata = DiscoveryClient::new()
+        .fetch_server_metadata("https://auth.example.com")
+        .await?;
+
+    let client = OAuthClient::new("my-client")
+        .with_redirect_uri("https://app.example.com/callback")
+        .with_token_store(Arc::new(InMemoryTokenStore::new()));
+
+    // 1. строим запрос авторизации (state и PKCE генерируются)
+    let auth = client
+        .authorization_request(&metadata)
+        .with_scopes(["read"])
+        .with_resource("https://api.example.com")
+        .build()?;
+
+    // 2. отправляем пользователя на `auth.url`; затем в callback-редиректе:
+    let (code, state) = ("code", "state");
+    assert!(auth.matches_state(state)); // всегда проверяйте — защита от CSRF
+
+    // 3. обмениваем код на токены (verifier PKCE идёт вместе с запросом)
+    let tokens = client.exchange_code(&metadata, code, &auth).await?;
+    client.store_tokens("alice", &tokens);
+
+    // 4. позже — отдаётся из хранилища, прозрачно обновляется при устаревании:
+    let tokens = client.token("alice", &metadata).await?;
+    Ok(())
+}
+```
+
+[`AuthorizationRequest`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html), возвращаемый методом [`build()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.build), содержит `url` для редиректа, `state` для проверки в callback и пару PKCE. Он реализует `Serialize`/`Deserialize`, так что веб-приложение может сохранить его в сессии между редиректом и callback.
+
+Построитель запроса принимает [`with_scopes`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.with_scopes), [`with_resource`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.with_resource) (RFC 8707, можно повторять), [`with_state`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.with_state) (переопределить сгенерированное значение) и [`with_param`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequestBuilder.html#method.with_param) (например, OIDC `nonce` или `prompt`).
+
+::: warning
+Всегда проверяйте `state` из callback через [`matches_state`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.matches_state) **до** обмена кода — это ваша защита от CSRF.
+:::
+
+### Прозрачное обновление
+
+[`token(key, &metadata)`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.token) читает сохранённые токены и незаметно обновляет устаревший access-токен. Он возвращает `Ok(None)`, когда требуется интерактивная авторизация — ничего не сохранено, у записи нет refresh-токена или сервер отклонил refresh-токен (`invalid_grant`); в последних случаях «мёртвая» запись удаляется из хранилища. Можно также обновить явно через [`refresh`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.refresh).
+
+### Конфиденциальные клиенты
+
+Без секрета клиент работает как **публичный клиент** (защитой служит PKCE). Добавьте секрет, чтобы аутентифицироваться на token-эндпоинте:
+
+```rust
+use volga_oauth_client::{ClientAuthMethod, OAuthClient};
+
+let client = OAuthClient::new("my-client")
+    .with_secret("s3cret")
+    // `client_secret_basic` (по-умолчанию) или `client_secret_post`
+    .with_auth_method(ClientAuthMethod::Post);
+```
+
+## Хранилище токенов
+
+Сохранение выполняется через трейт [`TokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.TokenStore.html). [`InMemoryTokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.InMemoryTokenStore.html) — встроенная реализация в памяти процесса, подходящая для CLI, тестов и одноинстансовых сервисов; всё долговременное (БД, зашифрованный файл, связка ключей ОС) реализуется одной реализацией трейта.
+
+```rust
+use volga_oauth_client::{TokenSet, TokenStore};
+
+struct MyStore;
+
+impl TokenStore for MyStore {
+    fn get(&self, key: &str) -> Option<TokenSet> { /* ... */ None }
+    fn put(&self, key: &str, tokens: &TokenSet) { /* ... */ }
+    fn remove(&self, key: &str) { /* ... */ }
+}
+```
+
+Ключ выбирает приложение — обычно идентификатор пользователя или сессии, при необходимости в сочетании с ресурсом, когда один клиент обслуживает несколько аудиторий. [`TokenSet`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html) содержит access-токен, опциональный refresh-токен, выданный scope, OIDC `id_token` (передаётся как есть, без валидации) и абсолютное время `expires_at`; в выводе `Debug` токены скрыты.
+
+## Динамическая регистрация клиентов
+
+[`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) отправляет [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientMetadata.html) на registration-эндпоинт сервера (RFC 7591) и возвращает выданные учётные данные. [`OAuthClient::from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration) принимает их и создаёт готовый к использованию клиент:
+
+```rust
+use volga_oauth_client::{ClientMetadata, DiscoveryClient, OAuthClient, RegistrationClient};
+
+# async fn register() -> Result<(), volga_oauth_client::ClientError> {
+let metadata = DiscoveryClient::new()
+    .fetch_server_metadata("https://auth.example.com")
+    .await?;
+
+let registered = RegistrationClient::new()
+    .register(
+        &metadata,
+        &ClientMetadata::new()
+            .with_redirect_uris(["https://app.example.com/callback"])
+            .with_client_name("My App"),
+    )
+    .await?;
+
+// готовый к использованию клиент с выданными учётными данными
+let client = OAuthClient::from_registration(&registered)?;
+# Ok(())
+# }
+```
+
+Для серверов, не разрешающих открытую регистрацию, добавьте начальный токен доступа через [`with_initial_access_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html#method.with_initial_access_token).
+
+::: info
+Протокол управления RFC 7592 (чтение, обновление и удаление регистрации) не реализован, но пара `registration_access_token` / `registration_client_uri` из ответа доступна для приложений, которым она нужна.
+:::
+
+## Транспортная политика и ошибки
+
+[`ClientConfig`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientConfig.html) несёт политику, общую для всех операций клиента — принудительный HTTPS, таймауты на запрос и лимиты редиректов. Значения по-умолчанию безопасны для продакшена; чаще всего переопределяют отключение HTTPS для локального сервера разработки:
+
+```rust
+use std::time::Duration;
+use volga_oauth_client::{ClientConfig, OAuthClient};
+
+let config = ClientConfig::new()
+    .require_https(false)              // только для локальной разработки
+    .with_timeout(Duration::from_secs(5))
+    .with_max_redirects(0);
+
+let client = OAuthClient::new("my-client").with_config(config);
+```
+
+[`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) отделяет разобранный ответ об ошибке OAuth (`Protocol`, несущий [`OAuthError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthError.html) из RFC 6749 §5.2) от ошибок транспорта, декодирования, небезопасного URL и валидации — так вы можете отличить «сервер ответил `invalid_grant`» от «соединение оборвалось».
+
+## Примеры
+* [OAuth Flow](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_flow/src/main.rs) — полный флоу discovery → авторизация → обмен кода → вызов защищённого маршрута, реализованный через `volga-oauth-client`.

--- a/docs/ru/security-access/oauth-client.md
+++ b/docs/ru/security-access/oauth-client.md
@@ -29,21 +29,21 @@ volga-oauth-client = { version = "..." }
 [`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) разрешает well-known discovery-URL, загружает документы по HTTPS и проверяет каждый на соответствие идентификатору, для которого он был запрошен (RFC 8414 §3.3 / RFC 9728 §3.3):
 
 ```rust
-use volga_oauth_client::DiscoveryClient;
+use volga_oauth_client::{ClientError, DiscoveryClient};
 
-# async fn discover() -> Result<(), volga_oauth_client::ClientError> {
-let client = DiscoveryClient::new();
+async fn discover() -> Result<(), ClientError> {
+    let client = DiscoveryClient::new();
 
-// напрямую по идентификатору эмитента (RFC 8414 или путь OIDC):
-let server = client.fetch_server_metadata("https://auth.example.com").await?;
+    // напрямую по идентификатору эмитента (RFC 8414 или путь OIDC):
+    let server = client.fetch_server_metadata("https://auth.example.com").await?;
 
-// или начиная с ресурса и следуя к его серверу авторизации:
-let resource = client.fetch_resource_metadata("https://api.example.com").await?;
-let server = client.discover_authorization_server(&resource).await?;
+    // или начиная с ресурса и следуя к его серверу авторизации:
+    let resource = client.fetch_resource_metadata("https://api.example.com").await?;
+    let server = client.discover_authorization_server(&resource).await?;
 
-assert!(server.token_endpoint.is_some());
-# Ok(())
-# }
+    assert!(server.token_endpoint.is_some());
+    Ok(())
+}
 ```
 
 * [`fetch_server_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_server_metadata) / [`fetch_oidc_metadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html#method.fetch_oidc_metadata) — один и тот же вид документа по путям RFC 8414 и OIDC Discovery.
@@ -141,26 +141,28 @@ impl TokenStore for MyStore {
 [`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) отправляет [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientMetadata.html) на registration-эндпоинт сервера (RFC 7591) и возвращает выданные учётные данные. [`OAuthClient::from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration) принимает их и создаёт готовый к использованию клиент:
 
 ```rust
-use volga_oauth_client::{ClientMetadata, DiscoveryClient, OAuthClient, RegistrationClient};
+use volga_oauth_client::{
+    ClientError, ClientMetadata, DiscoveryClient, OAuthClient, RegistrationClient,
+};
 
-# async fn register() -> Result<(), volga_oauth_client::ClientError> {
-let metadata = DiscoveryClient::new()
-    .fetch_server_metadata("https://auth.example.com")
-    .await?;
+async fn register() -> Result<(), ClientError> {
+    let metadata = DiscoveryClient::new()
+        .fetch_server_metadata("https://auth.example.com")
+        .await?;
 
-let registered = RegistrationClient::new()
-    .register(
-        &metadata,
-        &ClientMetadata::new()
-            .with_redirect_uris(["https://app.example.com/callback"])
-            .with_client_name("My App"),
-    )
-    .await?;
+    let registered = RegistrationClient::new()
+        .register(
+            &metadata,
+            &ClientMetadata::new()
+                .with_redirect_uris(["https://app.example.com/callback"])
+                .with_client_name("My App"),
+        )
+        .await?;
 
-// готовый к использованию клиент с выданными учётными данными
-let client = OAuthClient::from_registration(&registered)?;
-# Ok(())
-# }
+    // готовый к использованию клиент с выданными учётными данными
+    let client = OAuthClient::from_registration(&registered)?;
+    Ok(())
+}
 ```
 
 Для серверов, не разрешающих открытую регистрацию, добавьте начальный токен доступа через [`with_initial_access_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html#method.with_initial_access_token).

--- a/docs/ru/security-access/oauth.md
+++ b/docs/ru/security-access/oauth.md
@@ -1,0 +1,210 @@
+# OAuth 2.1 и OpenID Connect
+
+Волга предоставляет полноценную основу для OAuth 2.1 / OpenID Connect поверх [аутентификации через Bearer Token](/ru/security-access/auth.html). Она позволяет создавать **сервер ресурсов (resource server)**, который валидирует токены по опубликованным ключам OAuth 2.1 / OIDC-эмитента (issuer) — без общего секрета — а также **отдавать документы метаданных (discovery)**, необходимые клиентам для запуска флоу.
+
+Типы уровня протокола (модели ошибок, документы метаданных, построитель заголовка `WWW-Authenticate`, вывод well-known URL) находятся в модуле [`volga::auth::oauth`](https://docs.rs/volga/latest/volga/auth/oauth/index.html) и совместно используются с отдельным [OAuth-клиентом](/ru/security-access/oauth-client.html).
+
+## Feature-флаги
+
+| Feature | Что включает |
+|---|---|
+| `oauth` | Базовые типы OAuth 2.1 / OIDC в `volga::auth::oauth` и отдачу метаданных (включается вместе с `jwt-auth`). |
+| `oauth-client` | Валидацию токенов по эмитенту — `App::with_oauth` / `App::use_oauth`. Включает `jwt-auth`. |
+
+```toml
+[dependencies]
+volga = { version = "...", features = ["oauth-client"] }
+```
+
+## Валидация токенов по эмитенту
+
+Вместо настройки статического [`DecodingKey`](https://docs.rs/volga/latest/volga/auth/decoding_key/struct.DecodingKey.html) можно направить Bearer-аутентификацию на OAuth 2.1 / OIDC-эмитента. Волга загружает метаданные сервера эмитента (RFC 8414, с откатом на OpenID Connect Discovery) и объявленный им набор ключей JSON Web Key Set, после чего валидирует входящие JWT, выбирая ключ по `kid` каждого токена.
+
+Опишите эмитента через [`with_oauth(...)`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth) и явно активируйте через [`use_oauth()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth):
+
+```rust
+use serde::Deserialize;
+use volga::{
+    App, ok,
+    auth::{AuthClaims, roles},
+};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new()
+        // аудитория, срок действия и прочие проверки токена остаются здесь
+        .with_bearer_auth(|auth| auth.with_aud(["https://api.example.com"]))
+        // ключи и ограничение `iss` приходят от эмитента
+        .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"));
+
+    // явное подключение — до этого вызова валидация по эмитенту не работает
+    app.use_oauth();
+
+    app.map_get("/protected", protected)
+        .authorize::<Claims>(roles(["admin"]));
+
+    app.run().await
+}
+
+async fn protected() -> &'static str {
+    "Hello from the protected route!"
+}
+
+#[derive(Clone, Deserialize)]
+struct Claims {
+    role: String,
+}
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> {
+        Some(&self.role)
+    }
+}
+```
+
+При валидации по эмитенту статический ключ расшифровки не нужен — ключи разрешаются во время выполнения. Всё остальное (`aud`, срок действия, scope и роли) по-прежнему берётся из [`with_bearer_auth`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_bearer_auth).
+
+::: info
+Claim `iss` автоматически ограничивается настроенным эмитентом и делается **обязательным** — токены без него или с другим эмитентом отклоняются.
+:::
+
+### Жизненный цикл ключей
+
+Ключи загружаются лениво при первом запросе и кэшируются, поэтому в типичном случае валидация токена не требует обращения по сети. Кэш поддерживает себя сам:
+
+* Токен с **неизвестным `kid`** запускает обновление (ротация ключей), ограниченное по частоте через [`with_refresh_cooldown`](https://docs.rs/volga/latest/volga/auth/struct.OAuthConfig.html#method.with_refresh_cooldown) (по-умолчанию 60 с); одновременные промахи разделяют одно обновление.
+* Известные `kid` **перепроверяются** у эмитента, как только кэшированный набор становится старше [`with_max_key_age`](https://docs.rs/volga/latest/volga/auth/struct.OAuthConfig.html#method.with_max_key_age) (по-умолчанию 15 минут), так что отозванный или переизданный `kid` перестаёт валидироваться без перезапуска.
+* Пока эмитент **недоступен**, а ключи уже были загружены, продолжает работать последний известный набор — сбой эмитента не роняет валидацию токенов. Если же ключи ни разу не загрузились, защищённые маршруты отвечают `503` (проблема на стороне сервера), а не обвиняют токен.
+
+### Конфигурация
+
+Эмитент обязателен; у всего остального есть безопасные для продакшена значения по-умолчанию.
+
+```rust
+use std::time::Duration;
+use volga::App;
+
+let app = App::new()
+    .with_bearer_auth(|auth| auth.with_aud(["https://api.example.com"]))
+    .with_oauth(|oauth| oauth
+        .with_issuer("https://auth.example.com")
+        .with_refresh_cooldown(Duration::from_secs(30))
+        .with_max_key_age(Duration::from_secs(600))
+        // транспортная политика для discovery / JWKS
+        .with_client_config(|client| client.require_https(true)));
+```
+
+Для локального эмитента, работающего по обычному HTTP, ослабьте транспортную политику:
+
+```rust
+let app = App::new()
+    .with_oauth(|oauth| oauth
+        .with_issuer("http://127.0.0.1:5000")
+        .with_client_config(|client| client.require_https(false)));
+```
+
+С feature `config` те же параметры можно описать в секции `[oauth.client]` файла конфигурации — поля из файла переопределяют вызовы построителя, неизвестные ключи приводят к ошибке при старте, а активация всё так же требует явного вызова `App::use_oauth()` в коде:
+
+```toml
+[oauth.client]
+issuer = "https://auth.example.com"
+refresh_cooldown_secs = 60   # опционально
+max_key_age_secs = 900       # опционально
+require_https = true         # опционально
+timeout_secs = 30            # опционально
+max_redirects = 5            # опционально
+```
+
+## Отдача документов метаданных
+
+Сервер ресурсов сообщает клиентам, где аутентифицироваться; сервер авторизации публикует свои эндпоинты и ключи. Волга отдаёт оба discovery-документа прямо из вашего приложения.
+
+### Protected Resource Metadata (RFC 9728)
+
+Настройте через [`with_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth_resource_metadata) (или [`set_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.set_oauth_resource_metadata) для передачи значения целиком, включая сокращение через `&str`-идентификатор) и отдайте через [`use_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth_resource_metadata):
+
+```rust
+let mut app = App::new()
+    .with_oauth_resource_metadata(|metadata| metadata
+        .with_resource("https://api.example.com")
+        .with_authorization_servers(["https://auth.example.com"])
+        .with_scopes(["read", "write"])
+        .with_bearer_methods(["header"]));
+
+// GET /.well-known/oauth-protected-resource
+app.use_oauth_resource_metadata();
+```
+
+Когда настроена Bearer-аутентификация, выведенный URL метаданных автоматически объявляется в заголовках `WWW-Authenticate` (RFC 9728 §5.1), так что неаутентифицированный клиент может узнать, где ему аутентифицироваться, и начать флоу.
+
+### Authorization Server Metadata (RFC 8414) и OIDC Discovery
+
+Приложения, которые сами являются сервером авторизации, публикуют свои эндпоинты через [`with_oauth_server_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth_server_metadata) и отдают документ по одному или обоим discovery-путям:
+
+```rust
+let mut app = App::new()
+    .with_oauth_server_metadata(|metadata| metadata
+        .with_issuer("https://auth.example.com")
+        .with_authorization_endpoint("https://auth.example.com/authorize")
+        .with_token_endpoint("https://auth.example.com/token")
+        .with_jwks_uri("https://auth.example.com/jwks"));
+
+// серверы авторизации обычно публикуют один и тот же документ по обоим путям:
+app.use_oauth_server_metadata()  // GET /.well-known/oauth-authorization-server
+   .use_oidc_metadata();         // GET /.well-known/openid-configuration
+```
+
+::: tip
+Замыкание для метаданных сервера предзаполняется значениями OAuth 2.1: `response_types_supported = ["code"]` и `grant_types_supported = ["authorization_code"]`. OIDC-специфичные поля, обязательные для совместимого документа провайдера (`subject_types_supported`, `id_token_signing_alg_values_supported`, `userinfo_endpoint`, …), можно задать через [`with_additional_field(...)`](https://docs.rs/volga/latest/volga/auth/oauth/struct.AuthorizationServerMetadata.html#method.with_additional_field).
+:::
+
+Оба документа также могут приходить из секций `[oauth.resource]` / `[oauth.server]` файла конфигурации (feature `config`); файл переопределяет предыдущие вызовы построителя. Сокращение `set_*` настраивает минимальный документ только по идентификатору:
+
+```rust
+let mut app = App::new()
+    .set_oauth_resource_metadata("https://api.example.com")
+    .set_oauth_server_metadata("https://auth.example.com");
+
+app.use_oauth_resource_metadata();
+app.use_oauth_server_metadata().use_oidc_metadata();
+```
+
+## Полный флоу
+
+Собирая всё вместе, серверу ресурсов нужно всего несколько строк — валидация токенов напрямую привязана к опубликованным ключам эмитента, и нигде не настроен ни один секрет:
+
+```rust
+use volga::{App, auth::{AuthClaims, roles}, ok};
+use serde::Deserialize;
+
+#[derive(Clone, Deserialize)]
+struct Claims { role: String }
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> { Some(&self.role) }
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new()
+        .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"))
+        // объявляется в заголовках WWW-Authenticate
+        .with_oauth_resource_metadata(|m| m
+            .with_resource("https://api.example.com")
+            .with_authorization_servers(["https://auth.example.com"]));
+
+    app.use_oauth();
+    app.use_oauth_resource_metadata();
+
+    app.map_get("/protected", || async { ok!("Hello from the protected route!") })
+        .authorize::<Claims>(roles(["admin"]));
+
+    app.run().await
+}
+```
+
+Клиентская сторона того же флоу — discovery, обмен Authorization Code + PKCE и вызов защищённого маршрута — описана на странице [OAuth 2.1 Клиент](/ru/security-access/oauth-client.html).
+
+## Примеры
+* [OAuth Flow](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_flow/src/main.rs) — полный флоу Authorization Code + PKCE между сервером авторизации, сервером ресурсов и клиентом в одном процессе.
+* [OAuth Metadata](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_metadata/src/main.rs) — отдача discovery-документов RFC 8414 / RFC 9728 / OIDC.


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for OAuth 2.1 and OpenID Connect support in Volga, covering both server-side resource validation and client-side flows.

## Key Changes

- **New documentation pages added:**
  - `docs/en/security-access/oauth.md` - OAuth 2.1 & OpenID Connect server-side guide covering:
    - Token validation against OAuth 2.1/OIDC issuers
    - Key lifecycle and caching strategy
    - Configuration options for issuer-based validation
    - Serving Protected Resource Metadata (RFC 9728)
    - Serving Authorization Server Metadata (RFC 8414) and OIDC Discovery documents
    - Complete example of a resource server with issuer-based token validation
  
  - `docs/en/security-access/oauth-client.md` - OAuth 2.1 Client guide covering:
    - Discovery client for fetching server metadata and JWKS
    - Authorization Code + PKCE flow implementation
    - Token store abstraction and in-memory implementation
    - Dynamic Client Registration (RFC 7591)
    - Transport policy and error handling
  
  - Russian translations of both documents (`docs/ru/security-access/oauth.md` and `docs/ru/security-access/oauth-client.md`)

- **Updated existing documentation:**
  - Enhanced `docs/en/security-access/auth.md` with a section on validating tokens against OAuth 2.1/OIDC issuers
  - Enhanced `docs/ru/security-access/auth.md` with Russian translation of the same section

- **Updated navigation:**
  - Modified `docs/.vuepress/config.js` to include the new OAuth documentation pages in the Security & Access section navigation

## Notable Details

- Documentation includes practical code examples for both server and client implementations
- Covers production-safe defaults and configuration options
- Explains key lifecycle management including lazy loading, caching, and refresh strategies
- Provides guidance on both public and confidential client authentication methods
- Includes references to RFC standards (RFC 8414, RFC 9728, RFC 7591, RFC 8707)
- Bilingual documentation (English and Russian) maintains consistency across the documentation site

https://claude.ai/code/session_019RQ6ZxaopAEGKJVHDKfE1U