### PR TITLE
Fix broken links in OAuth documentation

### DIFF
--- a/docs/en/security-access/auth.md
+++ b/docs/en/security-access/auth.md
@@ -216,7 +216,7 @@ let mut app = App::new()
 app.use_oauth();
 ```
 
-See the [OAuth 2.1 & OpenID Connect](/en/security-access/oauth.html) page for the full flow (issuer-based validation, key rotation and metadata serving) and the [OAuth 2.1 Client](/en/security-access/oauth-client.html) page for driving the Authorization Code + PKCE flow.
+See the [OAuth 2.1 & OpenID Connect](./oauth.md) page for the full flow (issuer-based validation, key rotation and metadata serving) and the [OAuth 2.1 Client](./oauth-client.md) page for driving the Authorization Code + PKCE flow.
 
 ## Defining Claims
 

--- a/docs/en/security-access/oauth.md
+++ b/docs/en/security-access/oauth.md
@@ -1,8 +1,8 @@
 # OAuth 2.1 & OpenID Connect
 
-Volga ships a full OAuth 2.1 / OpenID Connect foundation on top of its [Bearer Token authentication](/en/security-access/auth.html). It lets you build **resource servers** that validate tokens against an OAuth 2.1 / OIDC issuer's published keys — with no shared secret — and **serve the discovery metadata documents** clients need to start a flow.
+Volga ships a full OAuth 2.1 / OpenID Connect foundation on top of its [Bearer Token authentication](./auth.md). It lets you build **resource servers** that validate tokens against an OAuth 2.1 / OIDC issuer's published keys — with no shared secret — and **serve the discovery metadata documents** clients need to start a flow.
 
-The protocol-level types (error models, metadata documents, the `WWW-Authenticate` challenge builder, well-known URL derivation) live under [`volga::auth::oauth`](https://docs.rs/volga/latest/volga/auth/oauth/index.html) and are shared with the standalone [OAuth client](/en/security-access/oauth-client.html).
+The protocol-level types (error models, metadata documents, the `WWW-Authenticate` challenge builder, well-known URL derivation) live under [`volga::auth::oauth`](https://docs.rs/volga/latest/volga/auth/oauth/index.html) and are shared with the standalone [OAuth client](./oauth-client.md).
 
 ## Feature flags
 
@@ -72,8 +72,8 @@ The `iss` claim is constrained to the configured issuer automatically and made *
 
 Keys are fetched lazily on the first request and cached, so token validation costs no network round-trip in the common case. The cache maintains itself:
 
-* A token with an **unknown `kid`** triggers a refresh (key rotation), rate-limited by [`with_refresh_cooldown`](https://docs.rs/volga/latest/volga/auth/struct.OAuthConfig.html#method.with_refresh_cooldown) (default 60 s); concurrent misses share a single refresh.
-* Known `kid`s are **re-checked** with the issuer once the cached set is older than [`with_max_key_age`](https://docs.rs/volga/latest/volga/auth/struct.OAuthConfig.html#method.with_max_key_age) (default 15 minutes), so a revoked or re-keyed `kid` stops validating without a restart.
+* A token with an **unknown `kid`** triggers a refresh (key rotation), rate-limited by [`with_refresh_cooldown`](https://docs.rs/volga/latest/volga/auth/oauth_client/struct.OAuthConfig.html#method.with_refresh_cooldown) (default 60 s); concurrent misses share a single refresh.
+* Known `kid`s are **re-checked** with the issuer once the cached set is older than [`with_max_key_age`](https://docs.rs/volga/latest/volga/auth/oauth_client/struct.OAuthConfig.html#method.with_max_key_age) (default 15 minutes), so a revoked or re-keyed `kid` stops validating without a restart.
 * While the issuer is **unreachable** and keys were already loaded, the last known set keeps serving — an issuer outage does not take token validation down with it. When no keys have ever loaded, protected routes answer `503` (a server-side problem) rather than blaming the token.
 
 ### Configuration
@@ -203,7 +203,7 @@ async fn main() -> std::io::Result<()> {
 }
 ```
 
-The client side of the same flow — discovery, the Authorization Code + PKCE exchange and calling the protected route — is covered on the [OAuth 2.1 Client](/en/security-access/oauth-client.html) page.
+The client side of the same flow — discovery, the Authorization Code + PKCE exchange and calling the protected route — is covered on the [OAuth 2.1 Client](./oauth-client.md) page.
 
 ## Examples
 * [OAuth Flow](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_flow/src/main.rs) — a complete Authorization Code + PKCE flow between an authorization server, a resource server and a client, in one process.

--- a/docs/ru/security-access/auth.md
+++ b/docs/ru/security-access/auth.md
@@ -215,7 +215,7 @@ let mut app = App::new()
 app.use_oauth();
 ```
 
-Полный флоу (валидация по эмитенту, ротация ключей и отдача метаданных) описан на странице [OAuth 2.1 и OpenID Connect](/ru/security-access/oauth.html), а запуск флоу Authorization Code + PKCE — на странице [OAuth 2.1 Клиент](/ru/security-access/oauth-client.html).
+Полный флоу (валидация по эмитенту, ротация ключей и отдача метаданных) описан на странице [OAuth 2.1 и OpenID Connect](./oauth.md), а запуск флоу Authorization Code + PKCE — на странице [OAuth 2.1 Клиент](./oauth-client.md).
 
 ## Определение структуры Claims
 

--- a/docs/ru/security-access/oauth.md
+++ b/docs/ru/security-access/oauth.md
@@ -1,8 +1,8 @@
 # OAuth 2.1 и OpenID Connect
 
-Волга предоставляет полноценную основу для OAuth 2.1 / OpenID Connect поверх [аутентификации через Bearer Token](/ru/security-access/auth.html). Она позволяет создавать **сервер ресурсов (resource server)**, который валидирует токены по опубликованным ключам OAuth 2.1 / OIDC-эмитента (issuer) — без общего секрета — а также **отдавать документы метаданных (discovery)**, необходимые клиентам для запуска флоу.
+Волга предоставляет полноценную основу для OAuth 2.1 / OpenID Connect поверх [аутентификации через Bearer Token](./auth.md). Она позволяет создавать **сервер ресурсов (resource server)**, который валидирует токены по опубликованным ключам OAuth 2.1 / OIDC-эмитента (issuer) — без общего секрета — а также **отдавать документы метаданных (discovery)**, необходимые клиентам для запуска флоу.
 
-Типы уровня протокола (модели ошибок, документы метаданных, построитель заголовка `WWW-Authenticate`, вывод well-known URL) находятся в модуле [`volga::auth::oauth`](https://docs.rs/volga/latest/volga/auth/oauth/index.html) и совместно используются с отдельным [OAuth-клиентом](/ru/security-access/oauth-client.html).
+Типы уровня протокола (модели ошибок, документы метаданных, построитель заголовка `WWW-Authenticate`, вывод well-known URL) находятся в модуле [`volga::auth::oauth`](https://docs.rs/volga/latest/volga/auth/oauth/index.html) и совместно используются с отдельным [OAuth-клиентом](./oauth-client.md).
 
 ## Feature-флаги
 
@@ -72,8 +72,8 @@ Claim `iss` автоматически ограничивается настро
 
 Ключи загружаются лениво при первом запросе и кэшируются, поэтому в типичном случае валидация токена не требует обращения по сети. Кэш поддерживает себя сам:
 
-* Токен с **неизвестным `kid`** запускает обновление (ротация ключей), ограниченное по частоте через [`with_refresh_cooldown`](https://docs.rs/volga/latest/volga/auth/struct.OAuthConfig.html#method.with_refresh_cooldown) (по-умолчанию 60 с); одновременные промахи разделяют одно обновление.
-* Известные `kid` **перепроверяются** у эмитента, как только кэшированный набор становится старше [`with_max_key_age`](https://docs.rs/volga/latest/volga/auth/struct.OAuthConfig.html#method.with_max_key_age) (по-умолчанию 15 минут), так что отозванный или переизданный `kid` перестаёт валидироваться без перезапуска.
+* Токен с **неизвестным `kid`** запускает обновление (ротация ключей), ограниченное по частоте через [`with_refresh_cooldown`](https://docs.rs/volga/latest/volga/auth/oauth_client/struct.OAuthConfig.html#method.with_refresh_cooldown) (по-умолчанию 60 с); одновременные промахи разделяют одно обновление.
+* Известные `kid` **перепроверяются** у эмитента, как только кэшированный набор становится старше [`with_max_key_age`](https://docs.rs/volga/latest/volga/auth/oauth_client/struct.OAuthConfig.html#method.with_max_key_age) (по-умолчанию 15 минут), так что отозванный или переизданный `kid` перестаёт валидироваться без перезапуска.
 * Пока эмитент **недоступен**, а ключи уже были загружены, продолжает работать последний известный набор — сбой эмитента не роняет валидацию токенов. Если же ключи ни разу не загрузились, защищённые маршруты отвечают `503` (проблема на стороне сервера), а не обвиняют токен.
 
 ### Конфигурация
@@ -203,7 +203,7 @@ async fn main() -> std::io::Result<()> {
 }
 ```
 
-Клиентская сторона того же флоу — discovery, обмен Authorization Code + PKCE и вызов защищённого маршрута — описана на странице [OAuth 2.1 Клиент](/ru/security-access/oauth-client.html).
+Клиентская сторона того же флоу — discovery, обмен Authorization Code + PKCE и вызов защищённого маршрута — описана на странице [OAuth 2.1 Клиент](./oauth-client.md).
 
 ## Примеры
 * [OAuth Flow](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_flow/src/main.rs) — полный флоу Authorization Code + PKCE между сервером авторизации, сервером ресурсов и клиентом в одном процессе.


### PR DESCRIPTION
* Internal cross-links used absolute `/en|ru/security-access/*.html` paths, which bypassed VuePress base handling and dropped the `/volga-docs/` prefix on the deployed site. Switch to relative `./*.md` links so the base is applied correctly.
* The OAuthConfig docs.rs links pointed at the re-export path `auth/struct.OAuthConfig.html` (404). Point them at the canonical module path `auth/oauth_client/struct.OAuthConfig.html`.

Both fixes applied to the English and Russian pages.


Claude-Session: https://claude.ai/code/session_019RQ6ZxaopAEGKJVHDKfE1U