### PR TITLE
Cover releases 0.9.3–0.9.8, and compile-check the site's Rust snippets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build site
+    # on main the Deploy Docs workflow already builds it
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run docs:build
+
+  snippets:
+    name: Compile Rust snippets
+    runs-on: ubuntu-latest
+    env:
+      VOLGA_VERSION: "0.9"
+      CARGO_TARGET_DIR: ${{ github.workspace }}/.snippet-target
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry and snippet target dir
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ env.CARGO_TARGET_DIR }}
+          key: snippets-${{ runner.os }}-volga${{ env.VOLGA_VERSION }}-${{ hashFiles('ci/check-snippets.py') }}
+          restore-keys: |
+            snippets-${{ runner.os }}-volga${{ env.VOLGA_VERSION }}-
+      - name: docs/ - the marked snippets
+        run: python3 ci/check-snippets.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/.vuepress/.cache
 docs/.vuepress/.temp
 docs/.vuepress/.dist
 docs/.vuepress/dist
+.snippet-target

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,69 @@
+# CI helpers
+
+## `check-snippets.py`
+
+Compiles the Rust snippets on the site against the published `volga` crates, so
+an example that drifted out of the API is caught here rather than by a reader.
+Run it the way CI does:
+
+```bash
+python3 ci/check-snippets.py
+```
+
+It scans both locales — the code in `docs/en` and `docs/ru` is meant to be
+identical, and a translation that drifted is exactly what this catches.
+
+### Marking a snippet
+
+Only marked blocks are checked, because plenty of snippets on the site lean on
+illustrative helpers that do not exist. Mark a block once it is self-contained,
+by adding a word to the fence's info string (VuePress ignores it and renders
+nothing):
+
+````markdown
+```rust compile
+use volga::{App, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+    app.map_get("/hello", || async { ok!("Hello, World!") });
+    app.run().await
+}
+```
+````
+
+| Marker | For |
+|---|---|
+| `compile` | a complete set of items; `fn main() {}` is appended when the block has none |
+| `compile-fragment` | statements meant to sit in a `main`; wrapped in an async fn that opens with `let mut app = App::new();`, with `use volga::*;` injected |
+| `features="..."` | the `volga` features to compile against — default `full`, so name this only for what sits outside it (`features="full jwt-derive"`) |
+| `skip` | opt a block out |
+
+The same words work in an HTML comment on the line above the fence, which wins
+over the info string:
+
+```markdown
+<!-- snippet: compile-fragment -->
+```
+
+### Adding a snippet that will not compile
+
+Leave it unmarked. That is the honest signal for a block showing a shape rather
+than a program — a trait impl with elided bodies, a call into a handler the
+page never defines. Keep the fence plain and the checker skips it.
+
+### Options
+
+```
+--docs-dir DIR            tree to scan (default: docs)
+--default-mode MODE       mode for unmarked blocks: none | compile | compile-fragment
+--default-features FEAT   features for blocks naming none
+--keep                    keep the scratch crates for inspection
+```
+
+`--default-mode compile` is how the current markers were chosen: run it, and
+every block that compiles unmarked is a candidate for a marker.
+
+`VOLGA_VERSION` (default `0.9`) selects the version the snippets are compiled
+against.

--- a/ci/check-snippets.py
+++ b/ci/check-snippets.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Compile the Rust snippets in docs/ that are marked for checking.
+
+VuePress ignores unknown words in a code fence's info string and does not
+render them, so the marker lives there:
+
+    ```rust compile
+    ```rust compile-fragment
+    ```rust compile features="full jwt-derive"
+
+An HTML comment on the line above a fence does the same and wins over the
+info string - useful where the fence already carries VuePress attributes:
+
+    <!-- snippet: compile -->
+    <!-- snippet: compile-fragment -->
+    <!-- snippet: features="full dev-cert" -->
+    <!-- snippet: skip -->
+
+Only marked blocks are checked. This is deliberate: plenty of snippets on the
+site reference illustrative helpers that do not exist (`long_running_task()`,
+`my_handler`, a `MyStore` with elided bodies, ...), and stubbing those
+generically would cost more than it catches. Mark a block once you have made
+it self-contained.
+
+Both locales are scanned, so a snippet is checked in `docs/en` and in
+`docs/ru` alike - the code in the two is meant to be identical, and a
+translation that drifted is exactly what this catches.
+
+Modes
+-----
+compile
+    The block is a complete set of items. Compiled as-is; `fn main() {}` is
+    appended when the block has no `fn main` of its own.
+
+compile-fragment
+    The block is a run of statements meant to sit in a `main`. The `use`
+    lines are hoisted to file scope and the rest is wrapped in
+
+        async fn __snippet() -> Result<(), Box<dyn std::error::Error>>
+
+    which opens with `let mut app = App::new();` and closes with `Ok(())`,
+    so fragments may use `app`, `?` and `await`. `use volga::*;` is injected,
+    since a fragment inherits the imports of the page around it.
+
+Features
+--------
+The feature set is `volga`'s. The default is `full`, which is what most of
+the site is written against; a page needing something outside it - the
+derive macros, the development certificate helper - names it per block:
+
+    ```rust compile features="full jwt-derive"
+
+Snippets that need different feature sets are compiled in separate crates,
+since Cargo unifies features across a workspace.
+
+Usage: python3 ci/check-snippets.py [--docs-dir docs] [--keep]
+                                    [--default-mode {none,compile,compile-fragment}]
+                                    [--default-features FEATURES]
+Env:   VOLGA_VERSION (default "0.9")
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+FENCE = re.compile(r"^```rust([^\n]*)\n(.*?)^```", re.S | re.M)
+# An optional directive on the line immediately above a fence. Wins over the
+# info string, and is how a block opts out of a tree checked by default.
+DIRECTIVE = re.compile(r"<!--\s*snippet:([^>]*?)-->\s*\n\Z", re.S)
+VOLGA_VERSION = os.environ.get("VOLGA_VERSION", "0.9")
+DEFAULT_FEATURES = "full"
+
+FRAGMENT_HEAD = (
+    "#[allow(unused, unused_imports)]\n"
+    "use volga::*;\n\n"
+    "#[allow(unused, deprecated)]\n"
+    "async fn __snippet() -> Result<(), Box<dyn std::error::Error>> {\n"
+    "    let mut app = App::new();\n"
+)
+FRAGMENT_TAIL = "    Ok(())\n}\nfn main() {}\n"
+
+
+def parse_meta(meta: str) -> tuple[str | None, str | None]:
+    """Return (mode, features) from a fence info string or a directive body."""
+    mode = None
+    for candidate in ("compile-fragment", "compile", "skip"):
+        if re.search(rf"(^|\s){re.escape(candidate)}(\s|$)", meta):
+            mode = candidate
+            break
+    features = None
+    m = re.search(r'features="([^"]+)"', meta)
+    if m:
+        features = m.group(1)
+    return mode, features
+
+
+def directive_before(text: str, start: int) -> tuple[str | None, str | None]:
+    """Read a `<!-- snippet: ... -->` sitting directly above the fence."""
+    m = DIRECTIVE.search(text, 0, start)
+    return parse_meta(m.group(1)) if m else (None, None)
+
+
+def render(mode: str, body: str) -> str:
+    if mode == "compile":
+        if re.search(r"^\s*(async\s+)?fn main\s*\(", body, re.M):
+            return body
+        return body + "\nfn main() {}\n"
+    uses, rest = [], []
+    for line in body.splitlines():
+        (uses if line.startswith("use ") else rest).append(line)
+    indented = "\n".join(("    " + l) if l.strip() else l for l in rest)
+    return "\n".join(uses) + "\n" + FRAGMENT_HEAD + indented + "\n" + FRAGMENT_TAIL
+
+
+def collect(
+    docs_dir: Path,
+    fallback_mode: str = "none",
+    fallback_features: str | None = None,
+) -> list[dict]:
+    snippets = []
+    for md in sorted(docs_dir.rglob("*.md")):
+        text = md.read_text(encoding="utf-8")
+        for idx, m in enumerate(FENCE.finditer(text)):
+            mode, features = parse_meta(m.group(1))
+            d_mode, d_features = directive_before(text, m.start())
+            mode = d_mode or mode or (fallback_mode if fallback_mode != "none" else None)
+            if mode is None or mode == "skip":
+                continue
+            line = text.count("\n", 0, m.start()) + 1
+            locale = md.relative_to(docs_dir).parts[0]
+            snippets.append(
+                {
+                    "name": f"{locale}_{md.stem}_{idx}".replace("-", "_"),
+                    "origin": f"{md}:{line}",
+                    "features": d_features
+                    or features
+                    or fallback_features
+                    or DEFAULT_FEATURES,
+                    "source": render(mode, m.group(2)),
+                }
+            )
+    return snippets
+
+
+def write_crate(crate: Path, features: str, group: list[dict]) -> None:
+    (crate / "src" / "bin").mkdir(parents=True)
+    feature_list = ", ".join(f'"{f}"' for f in features.split())
+    (crate / "Cargo.toml").write_text(
+        "[package]\n"
+        'name = "snippets"\n'
+        'version = "0.0.0"\n'
+        'edition = "2024"\n\n'
+        "[dependencies]\n"
+        f'volga = {{ version = "{VOLGA_VERSION}", features = [{feature_list}] }}\n'
+        f'volga-oauth-client = {{ version = "{VOLGA_VERSION}", '
+        'features = ["http1", "dpop", "private-key-jwt"] }\n'
+        f'volga-oauth-core = "{VOLGA_VERSION}"\n'
+        'tokio = { version = "1", features = ["full"] }\n'
+        'serde = { version = "1", features = ["derive"] }\n'
+        'serde_json = "1"\n'
+        'bytes = "1"\n'
+        'cookie = "0.18"\n'
+        'futures-util = "0.3"\n'
+        'http = "1"\n'
+        'http-body-util = "0.1"\n'
+        'tracing = "0.1"\n'
+        'tracing-subscriber = "0.3"\n\n'
+        # detach from any enclosing workspace
+        "[workspace]\n",
+        encoding="utf-8",
+    )
+    for s in group:
+        (crate / "src" / "bin" / f"{s['name']}.rs").write_text(
+            f"// from {s['origin']}\n{s['source']}", encoding="utf-8"
+        )
+
+
+def build(crate: Path) -> tuple[bool, set[str], str]:
+    """Compile every snippet in `crate`, reporting the files that failed.
+
+    `--keep-going` is what makes a run report *all* the broken snippets
+    rather than whichever one the scheduler reached first.
+    """
+    proc = subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--keep-going",
+            "--message-format=json",
+            "--manifest-path",
+            str(crate / "Cargo.toml"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    broken: set[str] = set()
+    for line in proc.stdout.splitlines():
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if message.get("reason") != "compiler-message":
+            continue
+        diagnostic = message.get("message", {})
+        if diagnostic.get("level") != "error":
+            continue
+        for span in diagnostic.get("spans", []):
+            name = Path(span.get("file_name", "")).name
+            if name.endswith(".rs"):
+                broken.add(name[: -len(".rs")])
+
+    return proc.returncode == 0, broken, proc.stderr
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--docs-dir", default="docs", type=Path)
+    ap.add_argument("--keep", action="store_true", help="keep the scratch crates")
+    ap.add_argument(
+        "--default-mode",
+        default="none",
+        choices=("none", "compile", "compile-fragment"),
+        help="mode for blocks carrying no marker (default: skip them)",
+    )
+    ap.add_argument(
+        "--default-features",
+        default=None,
+        help=f"features for blocks naming none (default: {DEFAULT_FEATURES})",
+    )
+    args = ap.parse_args()
+
+    snippets = collect(args.docs_dir, args.default_mode, args.default_features)
+    if not snippets:
+        print("no snippets marked for compilation - nothing to check")
+        return 0
+
+    by_features: dict[str, list[dict]] = {}
+    for s in snippets:
+        by_features.setdefault(s["features"], []).append(s)
+
+    print(f"checking {len(snippets)} snippet(s) in {len(by_features)} crate(s)\n")
+    root = Path(tempfile.mkdtemp(prefix="volga-snippets-"))
+    failed: list[dict] = []
+
+    try:
+        for features, group in sorted(by_features.items()):
+            crate = root / re.sub(r"[^a-z0-9]+", "_", features)
+            write_crate(crate, features, group)
+            print(f"  [{features}] {len(group)} snippet(s)")
+
+            ok, broken, stderr = build(crate)
+            if ok:
+                continue
+
+            named = [s for s in group if s["name"] in broken]
+            # an error carrying no usable span (a link failure, a bad
+            # manifest) belongs to the crate rather than to one snippet
+            failed.extend(named or group)
+            print(f"\n--- FAILED: features = {features} ---")
+            for s in named:
+                print(f"  {s['origin']}")
+            print(stderr)
+    finally:
+        if args.keep:
+            print(f"\nscratch crates kept at {root}")
+        else:
+            shutil.rmtree(root, ignore_errors=True)
+
+    if failed:
+        print(f"\nFAIL - {len(failed)} snippet(s) did not compile:")
+        for s in failed:
+            print(f"  {s['origin']}")
+        return 1
+    print(f"\nOK - all {len(snippets)} snippet(s) compiled")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -58,7 +58,7 @@ export default defineUserConfig({
           {
             text: 'Requests & Responses',
             prefix: '/en/requests-responses/',
-            children: ['headers', 'json-payload', 'form', 'files', 'multipart', 'cookie'],
+            children: ['headers', 'json-payload', 'form', 'files', 'multipart', 'body', 'cookie'],
           },
           {
             text: 'Middleware & Infrastructure',
@@ -68,12 +68,12 @@ export default defineUserConfig({
           {
             text: 'Security & Access',
             prefix: '/en/security-access/',
-            children: ['auth', 'oauth', 'oauth-client'],
+            children: ['auth', 'oauth', 'oauth-client', 'machine-to-machine', 'dpop'],
           },
           {
             text: 'Reliability & Observability',
             prefix: '/en/reliability-observability/',
-            children: ['errors', 'tracing', 'cancellation'],
+            children: ['errors', 'tracing', 'cancellation', 'graceful-shutdown'],
           },
           {
             text: 'Protocols & Realtime',
@@ -116,7 +116,7 @@ export default defineUserConfig({
           {
             text: 'Запросы и ответы',
             prefix: '/ru/requests-responses/',
-            children: ['headers', 'json-payload', 'form', 'files', 'multipart', 'cookie'],
+            children: ['headers', 'json-payload', 'form', 'files', 'multipart', 'body', 'cookie'],
           },
           {
             text: 'Middleware и инфраструктура',
@@ -126,12 +126,12 @@ export default defineUserConfig({
           {
             text: 'Безопасность и доступ',
             prefix: '/ru/security-access/',
-            children: ['auth', 'oauth', 'oauth-client'],
+            children: ['auth', 'oauth', 'oauth-client', 'machine-to-machine', 'dpop'],
           },
           {
             text: 'Надежность и наблюдаемость',
             prefix: '/ru/reliability-observability/',
-            children: ['errors', 'tracing', 'cancellation'],
+            children: ['errors', 'tracing', 'cancellation', 'graceful-shutdown'],
           },
           {
             text: 'Протоколы и realtime',

--- a/docs/en/advanced-patterns/custom-trace-opt-head.md
+++ b/docs/en/advanced-patterns/custom-trace-opt-head.md
@@ -36,7 +36,7 @@ Here, the `HEAD` method returns headers without a body, often mirroring the head
 ## OPTIONS Method
 
 For specifically handling `OPTIONS` requests, use the [`map_options`](https://docs.rs/volga/latest/volga/app/router/trait.Router.html#tymethod.map_options) method to map this HTTP method:
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]

--- a/docs/en/getting-started/query-params.md
+++ b/docs/en/getting-started/query-params.md
@@ -6,7 +6,7 @@ If you'd like to use a struct, similarly to [`NamedPath<T>`](https://docs.rs/vol
 ## Access Query Parameters
 
 To demonstrate how to access query parameters, consider the following example:
-```rust
+```rust compile
 use volga::{App, Query, ok};
 use serde::Deserialize;
 
@@ -40,7 +40,7 @@ Hello World!
 ```
 ## Handling Multiple Query Parameters
 For APIs that require multiple query parameters, you can set them up similarly:
-```rust
+```rust compile
 use volga::{App, Query, ok};
 use serde::Deserialize;
 
@@ -77,7 +77,7 @@ For the example above if we run the `curl` command by ignoring some parameter, e
 Query parsing error: missing field `email`
 ```
 However, if we want to keep some of the parameters as optional, we can wrap them in [`Option<T>`](https://doc.rust-lang.org/std/option/) as follows:
-```rust
+```rust compile
 use volga::{App, Query, ok};
 use serde::Deserialize;
 

--- a/docs/en/getting-started/quick-start.md
+++ b/docs/en/getting-started/quick-start.md
@@ -26,7 +26,7 @@ tokio = { version = "...", features = ["full"] }
 ## Setup
 Create your main application in `main.rs`:
 
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]
@@ -45,16 +45,16 @@ async fn main() -> std::io::Result<()> {
 ```
 ## Detailed Walkthrough
 When the [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html) struct is instantiated, it represents your API and by default binds it to `http://localhost:7878`:
-```rust
+```rust compile-fragment
 let mut app = App::new();
 ```
 Or if you need to bind it to another socket, you can use the [`bind()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.bind) method like this:
-```rust
+```rust compile-fragment
 // Binds the server to http://localhost:5000
 let mut app = App::new().bind("localhost:5000");
 ```
 Since **v0.9.7**, [`bind()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.bind) accepts the full address grammar of [`tokio::net::TcpListener::bind`](https://docs.rs/tokio/latest/tokio/net/struct.TcpListener.html#method.bind):
-```rust
+```rust compile-fragment
 let app = App::new().bind("127.0.0.1:7878");      // IPv4 literal
 let app = App::new().bind("[::1]:7878");          // IPv6 literal
 let app = App::new().bind("::1:7878");            // unbracketed IPv6 literal
@@ -120,7 +120,7 @@ volga = { version = "..." }
 
 Your `main.rs` might then look like this:
 
-```rust
+```rust compile
 use volga::{App, ok};
 
 fn main() {

--- a/docs/en/getting-started/quick-start.md
+++ b/docs/en/getting-started/quick-start.md
@@ -53,6 +53,22 @@ Or if you need to bind it to another socket, you can use the [`bind()`](https://
 // Binds the server to http://localhost:5000
 let mut app = App::new().bind("localhost:5000");
 ```
+Since **v0.9.7**, [`bind()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.bind) accepts the full address grammar of [`tokio::net::TcpListener::bind`](https://docs.rs/tokio/latest/tokio/net/struct.TcpListener.html#method.bind):
+```rust
+let app = App::new().bind("127.0.0.1:7878");      // IPv4 literal
+let app = App::new().bind("[::1]:7878");          // IPv6 literal
+let app = App::new().bind("::1:7878");            // unbracketed IPv6 literal
+let app = App::new().bind("[fe80::1%eth0]:7878"); // zone-scoped IPv6 literal
+let app = App::new().bind("localhost:7878");      // host name
+let app = App::new().bind(([127, 0, 0, 1], 7878)); // anything that converts into a SocketAddr
+```
+Host names are resolved when the server starts — asynchronously, so the runtime is never blocked. If a name resolves to several addresses, they are tried in resolution order and the first one that can be bound wins.
+
+:::warning
+Before **v0.9.7**, an address that could not be parsed as a `SocketAddr` was silently replaced with `0.0.0.0:7878` on non-Windows targets. That included `localhost:3000` and `::1:3000` — so a server meant to stay on loopback listened on *every* interface with no error and no log line.
+
+An unusable address is now reported instead: [`run()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.run) returns an `io::Error`, and [`run_blocking()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.run_blocking) logs it and starts no server. If you rely on a loopback bind for security, upgrade.
+:::
 Next, map a specific handler to a route. For instance, mapping our handler to `GET /hello`:
 ```rust
 app.map_get("/hello", || {

--- a/docs/en/getting-started/route-groups.md
+++ b/docs/en/getting-started/route-groups.md
@@ -6,7 +6,7 @@ Volga provides a convenient mechanism for grouping routes using prefixes. This h
 
 Here is an example demonstrating how to use route groups in a Volga application:
 
-```rust
+```rust compile
 use volga::{App, HttpResult, ok};
 
 #[tokio::main]

--- a/docs/en/getting-started/route-params.md
+++ b/docs/en/getting-started/route-params.md
@@ -4,7 +4,7 @@ Volga offers robust routing configurations allowing you to harness dynamic route
 ## Example: Single Route Parameter
 
 Here's how to set up a simple dynamic route that greets a user by name:
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]
@@ -34,7 +34,7 @@ Hello sun!
 ```
 ## Example: Multiple Route Parameters
 You can also configure multiple parameters in a route. Here’s an example:
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]
@@ -60,7 +60,7 @@ So for the `hello/{descr}/{name}` it is supposed to be `|descr: String, name: St
 
 ## Using `NamedPath<T>`
 Alternatively, use the [`NamedPath<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/path/struct.NamedPath.html) to wrap the route parameters into a dedicated struct. Where `T` should be either deserializable struct or `HashMap`. Make sure that you also have [serde](https://crates.io/crates/serde) installed:
-```rust
+```rust compile
 use volga::{App, NamedPath, ok};
 use serde::Deserialize;
  

--- a/docs/en/middleware-infrastructure/compression.md
+++ b/docs/en/middleware-infrastructure/compression.md
@@ -22,7 +22,7 @@ volga = { version = "...", features = ["compression-brotli", "compression-gzip"]
 
 To use compression in your application, call the [`use_compression()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_compression) method in your `main.rs`:
 
-```rust
+```rust compile
 use volga::{App, ok};
 use serde::Serialize;
  

--- a/docs/en/middleware-infrastructure/config-files.md
+++ b/docs/en/middleware-infrastructure/config-files.md
@@ -37,7 +37,7 @@ msg = "World"
 
 Define a struct for your custom section and bind it during app setup:
 
-```rust
+```rust compile
 use volga::{App, Config, ok};
 use serde::Deserialize;
 
@@ -71,7 +71,7 @@ Volga provides three ways to load a config file:
 
 The simplest option — [`with_default_config()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_default_config) automatically discovers `app_config.toml` or `app_config.json` in the current working directory:
 
-```rust
+```rust compile-fragment
 let app = App::new().with_default_config();
 ```
 
@@ -160,7 +160,7 @@ let app = App::new().with_config(|cfg| {
 
 Use the [`Config<T>`](https://docs.rs/volga/latest/volga/config/struct.Config.html) extractor to access a bound section in any request handler. It performs one atomic load + `Arc::clone` per request — no deserialization at runtime:
 
-```rust
+```rust compile
 use volga::{App, Config, ok};
 use serde::Deserialize;
 

--- a/docs/en/middleware-infrastructure/cors.md
+++ b/docs/en/middleware-infrastructure/cors.md
@@ -13,7 +13,7 @@ volga = { version = "...", features = ["middleware"] }
 
 The following example demonstrates a permissive CORS configuration:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -37,7 +37,7 @@ By default, CORS is disabled. To avoid a runtime panic, you must call [`with_cor
 
 If you need a stricter configuration, you can specify allowed origins, headers, and methods:
 
-```rust
+```rust compile
 use volga::{App, http::Method};
 
 #[tokio::main]
@@ -76,7 +76,7 @@ Volga separates **CORS configuration** from **where it is applied**:
 
 If you configure only a named policy, routes will **not** get CORS unless you explicitly attach that policy via [`cors_with(...)`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.cors_with).
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -110,7 +110,7 @@ async fn main() -> std::io::Result<()> {
 
 You can attach a policy to a single endpoint:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]

--- a/docs/en/middleware-infrastructure/decompression.md
+++ b/docs/en/middleware-infrastructure/decompression.md
@@ -46,7 +46,7 @@ async fn main() -> std::io::Result<()> {
     app.run().await
 }
 ```
-Then you can test it with `curl` command after creating and packing the `users.json.gz` file which you can make from the response of the Response Compressions topic's [example](/volga-docs/en/getting-started/compression.html#example-of-usage):
+Then you can test it with `curl` command after creating and packing the `users.json.gz` file which you can make from the response of the Response Compressions topic's [example](/volga-docs/en/middleware-infrastructure/compression.html#example-of-usage):
 ```bash
 curl -v -X POST --location 'http://127.0.0.1:7878/users' \
     -H "Content-Type: application/json" \

--- a/docs/en/middleware-infrastructure/middleware.md
+++ b/docs/en/middleware-infrastructure/middleware.md
@@ -15,7 +15,7 @@ volga = { version = "...", features = ["middleware"] }
 
 The [`filter()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.filter) method allows you to define conditional logic (such as validation or access control) for a specific route or a group of routes.
 
-```rust
+```rust compile
 use volga::{App, Path};
 
 #[tokio::main]
@@ -44,7 +44,7 @@ async fn sum(x: i32, y: i32) -> i32 {
 
 The [`tap_req()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.tap_req) method gives you access to the [`HttpRequestMut`](https://docs.rs/volga/latest/volga/http/request/struct.HttpRequestMut.html), allowing you to inspect or mutate request before request processing.
 
-```rust
+```rust compile
 use volga::{App, HttpRequestMut, headers};
 
 headers! {
@@ -70,7 +70,7 @@ async fn main() -> std::io::Result<()> {
 
 Use the [`map_ok()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_ok) method to transform or augment successful HTTP responses.
 
-```rust
+```rust compile
 use volga::{App, HttpResponse, HttpResult, headers};
 
 headers! {

--- a/docs/en/middleware-infrastructure/middleware.md
+++ b/docs/en/middleware-infrastructure/middleware.md
@@ -136,7 +136,7 @@ async fn produce_err() -> IoError {
 ```
 
 ::: tip
-By attaching [`map_err()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_err) to the [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html), you configure a global error handler. You can read more about advanced error handling [here](/volga-docs/en/reliability-observability/errors).
+By attaching [`map_err()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_err) to the [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html), you configure a global error handler. You can read more about advanced error handling [here](/volga-docs/en/reliability-observability/errors.html).
 :::
 
 ## Examples

--- a/docs/en/middleware-infrastructure/middlewares.md
+++ b/docs/en/middleware-infrastructure/middlewares.md
@@ -18,7 +18,7 @@ volga = { version = "...", features = ["middleware"] }
 ### Example: Sequential Middleware Execution
 
 Here’s a practical example of how to configure sequential middleware in Volga:
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]
@@ -63,7 +63,7 @@ async fn main() -> std::io::Result<()> {
 ```
 ### Example: Middleware Short-Cutting Pipeline
 The following example demonstrates how to shortcut the middleware pipeline to prevent the request handler from being executed. This approach can be particularly useful for implementing authorization filters or pre-request validations that may terminate the request early:
-```rust
+```rust compile
 use volga::{App, ok, status};
 
 #[tokio::main]

--- a/docs/en/middleware-infrastructure/parameterized-middleware.md
+++ b/docs/en/middleware-infrastructure/parameterized-middleware.md
@@ -28,7 +28,7 @@ Any type implementing this trait can be passed to [`attach()`](https://docs.rs/v
 ## Example: A `Timeout` Middleware
 
 Here is a small middleware that adds an artificial delay before the request is processed further. Its duration is configurable at registration time:
-```rust
+```rust compile
 use std::time::Duration;
 use volga::{App, HttpResult, middleware::{HttpContext, NextFn, Middleware}};
 
@@ -75,7 +75,7 @@ Use [`wrap()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.wra
 :::
 
 `attach()` also accepts closures, but type annotations on the arguments are required:
-```rust
+```rust compile
 use volga::{App, middleware::{HttpContext, NextFn}};
 
 #[tokio::main]
@@ -93,7 +93,7 @@ async fn main() -> std::io::Result<()> {
 ## Registering on Routes and Route Groups
 
 Parameterized middleware can also be attached to individual routes and [route groups](../getting-started/route-groups.md), not just to the entire application:
-```rust
+```rust compile
 use std::time::Duration;
 use volga::{App, HttpResult, middleware::{HttpContext, NextFn, Middleware}};
 
@@ -147,7 +147,7 @@ Built-in features such as [CORS](./cors.md), [authentication](../security-access
 
 The same parameterized approach works for the other middleware traits as well. Besides [`Middleware`](https://docs.rs/volga/latest/volga/middleware/handler/trait.Middleware.html), you can implement [`Filter`](https://docs.rs/volga/latest/volga/middleware/handler/trait.Filter.html), [`TapReq`](https://docs.rs/volga/latest/volga/middleware/handler/trait.TapReq.html), [`MapOk`](https://docs.rs/volga/latest/volga/middleware/handler/trait.MapOk.html), [`MapErr`](https://docs.rs/volga/latest/volga/http/endpoints/handlers/trait.MapErr.html), and [`With`](https://docs.rs/volga/latest/volga/middleware/handler/trait.With.html) on your own types. They are registered using the same methods as their closure counterparts — [`filter()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.filter), [`tap_req()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.tap_req), [`map_ok()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_ok), [`map_err()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_err), and [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with) respectively. For example, a reusable parameterized filter:
 
-```rust
+```rust compile
 use volga::{App, headers::HttpHeaders, middleware::Filter};
 
 #[tokio::main]

--- a/docs/en/middleware-infrastructure/rate-limiting.md
+++ b/docs/en/middleware-infrastructure/rate-limiting.md
@@ -59,7 +59,7 @@ Rate limiting middleware can be attached at three levels:
 
 A token bucket starts full (up to `capacity` tokens) and refills at a constant rate. Each request consumes one token. When the bucket is empty, requests are rejected until tokens are replenished.
 
-```rust
+```rust compile-fragment
 use volga::rate_limiting::TokenBucket;
 
 let bucket = TokenBucket::new(10, 5.0);
@@ -110,7 +110,7 @@ At this point, the policies exist but are **not yet active** — you still need 
 
 Apply rate limiting to all incoming requests:
 
-```rust
+```rust compile-fragment
 use volga::rate_limiting::by;
 
 app.use_token_bucket(by::ip());
@@ -205,7 +205,7 @@ For distributed scenarios (e.g. multiple instances behind a load balancer), you 
 
 Store traits are defined in the `volga_rate_limiter` crate and each requires a single atomic operation:
 
-```rust
+```rust compile
 use volga::rate_limiting::TokenBucketStore;
 use volga::rate_limiting::TokenBucketParams;
 

--- a/docs/en/middleware-infrastructure/static-files.md
+++ b/docs/en/middleware-infrastructure/static-files.md
@@ -32,7 +32,7 @@ project/
 
 After creating `html`, `css`, and `js` files, you can set up a minimal static file server in `main.rs`:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -60,7 +60,7 @@ If you have subfolders inside the content root, routes to their contents will al
 
 To serve a custom fallback file (e.g., `404.html`), use [`map_fallback_to_file()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_fallback_to_file), which internally calls [`map_fallback()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_fallback) to handle unknown paths.
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -84,7 +84,7 @@ Since fallback files are disabled by default, we explicitly set the `404.html` f
 
 A more concise version of the above code is:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -112,7 +112,7 @@ You can set [`with_fallback_file("index.html")`](https://docs.rs/volga/latest/vo
 
 Like fallback files, directory browsing is disabled by default. You can enable it using [`with_files_listing()`](https://docs.rs/volga/latest/volga/app/env/struct.HostEnv.html#method.with_files_listing). However, this is not recommended for production environments.
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -137,7 +137,7 @@ For more advanced scenarios, you can use the [`HostEnv`](https://docs.rs/volga/l
 
 Here’s how you can achieve the same configuration with `HostEnv`:
 
-```rust
+```rust compile
 use volga::{App, File, app::HostEnv};
 
 #[tokio::main]

--- a/docs/en/protocols-realtime/http.md
+++ b/docs/en/protocols-realtime/http.md
@@ -17,7 +17,7 @@ With `full`, HTTP/2 is used when possible, and it falls back to HTTP/1 automatic
 ## HTTP Methods
 Volga has a named `map_*` method for every standard verb, registered on an [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html) or on a [`RouteGroup`](https://docs.rs/volga/latest/volga/routing/struct.RouteGroup.html):
 
-```rust
+```rust compile-fragment
 app.map_get("/items", || async { ok!("list") });
 app.map_post("/items", || async { ok!("created") });
 app.map_put("/items/{id}", || async { ok!("updated") });
@@ -37,7 +37,7 @@ Starting with **v0.9.4**, Volga supports the HTTP `QUERY` method — a safe, ide
 
 Register a handler with [`map_query()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_query):
 
-```rust
+```rust compile
 use volga::{App, Json, ok};
 use serde::Deserialize;
 
@@ -75,7 +75,7 @@ Prefer putting complex selection criteria in the request body of a `QUERY` reque
 ### Any method
 Also since **v0.9.4**, [`map()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map) registers a route for any HTTP method. It is useful when the verb is only known at runtime, when the same handler serves several methods, or for non-standard verbs:
 
-```rust
+```rust compile
 use volga::{App, ok};
 use volga::http::Method;
 

--- a/docs/en/protocols-realtime/http.md
+++ b/docs/en/protocols-realtime/http.md
@@ -1,4 +1,6 @@
-# HTTP/1 and HTTP/2
+# HTTP Versions and Methods
+
+## HTTP/1 and HTTP/2
 Starting with **v0.3.1**, you can configure the HTTP version.
 If you add Volga like this, HTTP/1 is used by default:
 ```toml
@@ -11,3 +13,91 @@ To enable HTTP/2, add the `http2` feature or use `full`:
 volga = { version = "...", features = ["full"] }
 ```
 With `full`, HTTP/2 is used when possible, and it falls back to HTTP/1 automatically.
+
+## HTTP Methods
+Volga has a named `map_*` method for every standard verb, registered on an [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html) or on a [`RouteGroup`](https://docs.rs/volga/latest/volga/routing/struct.RouteGroup.html):
+
+```rust
+app.map_get("/items", || async { ok!("list") });
+app.map_post("/items", || async { ok!("created") });
+app.map_put("/items/{id}", || async { ok!("updated") });
+app.map_patch("/items/{id}", || async { ok!("patched") });
+app.map_delete("/items/{id}", || async { ok!("deleted") });
+app.map_head("/items", || async { ok!() });
+app.map_options("/items", || async { ok!() });
+app.map_trace("/items", || async { ok!() });
+```
+
+::: tip
+`HEAD` is mapped implicitly for every `GET` route, so you only need [`map_head`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_head) for a custom implementation. See [Custom Handling of HEAD, OPTIONS, and TRACE](/volga-docs/en/advanced-patterns/custom-trace-opt-head.html).
+:::
+
+### The `QUERY` method
+Starting with **v0.9.4**, Volga supports the HTTP `QUERY` method — a safe, idempotent verb that carries a request body, for searches too large or too structured to express in a URI query string.
+
+Register a handler with [`map_query()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_query):
+
+```rust
+use volga::{App, Json, ok};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct SearchQuery {
+    criteria: String
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_query("/search", |query: Json<SearchQuery>| async move {
+        // run the search by query.criteria...
+        ok!("search results...")
+    });
+
+    app.run().await
+}
+```
+
+Test it with `curl`:
+```bash
+> curl -X QUERY "http://localhost:7878/search" -H "Content-Type: application/json" -d '{"criteria":"volga"}'
+```
+
+::: warning
+Don't confuse [`map_query()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_query) with the [`Query<T>`](/volga-docs/en/getting-started/query-params.html) extractor: the former registers a route for the `QUERY` **verb**, the latter reads the URI **query string** of any request.
+:::
+
+::: tip
+Prefer putting complex selection criteria in the request body of a `QUERY` request. Use URI query parameters only for routing or cache-affecting metadata — tenant, locale, version, flags, pagination compatibility.
+:::
+
+### Any method
+Also since **v0.9.4**, [`map()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map) registers a route for any HTTP method. It is useful when the verb is only known at runtime, when the same handler serves several methods, or for non-standard verbs:
+
+```rust
+use volga::{App, ok};
+use volga::http::Method;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map(Method::GET, "/hello", || async {
+        ok!("Hello, World!")
+    });
+
+    // a string verb and a runtime-built pattern work as well
+    app.map("QUERY", format!("/search/{}", "v1"), || async {
+        ok!("search results...")
+    });
+
+    app.run().await
+}
+```
+
+The `method` argument accepts anything that converts into a [`Method`](https://docs.rs/http/latest/http/method/struct.Method.html) — including string verbs — and the pattern accepts both a borrowed `&str` (no allocation) and an owned `String` built at runtime.
+
+::: warning
+[`map()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map) **panics** if the method cannot be converted into a valid [`Method`](https://docs.rs/http/latest/http/method/struct.Method.html). Routes are registered at startup, so an invalid verb is a programming error rather than a runtime condition.
+:::

--- a/docs/en/protocols-realtime/https.md
+++ b/docs/en/protocols-realtime/https.md
@@ -78,7 +78,7 @@ openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 36
 
 ### Adjusting code to use certificate and private key
 If you generated a certificate and private key in the folder where your `Cargo.toml` is located, you can simply do the following:
-```rust
+```rust compile
 use volga::{App, tls::TlsConfig};
 
 #[tokio::main]
@@ -184,7 +184,7 @@ Because HSTS is enforced by the client, it has some limitations:
 * The application must check every HTTP request and redirect or reject the HTTP request.
 
 HSTS in Volga is enabled by default, however you may configure it by leveraging [`with_hsts()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_hsts) method:
-```rust
+```rust compile
 use volga::{App, tls::TlsConfig};
 
 #[tokio::main]

--- a/docs/en/protocols-realtime/sse.md
+++ b/docs/en/protocols-realtime/sse.md
@@ -6,7 +6,7 @@ Volga includes built-in support for [Server-Sent Events (SSE)](https://developer
 
 The example below demonstrates how to create a simple SSE endpoint. It maps a `GET` request to `/events`, sets the `text/event-stream` content type, and continuously sends the message `"Hello, world!"` once per second until the client disconnects:
 
-```rust
+```rust compile
 use volga::{App, http::sse::Message, sse_stream};
 use std::time::Duration;
 
@@ -35,7 +35,7 @@ Volga provides the [`Message`](https://docs.rs/volga/latest/volga/http/endpoints
 
 For simple text messages, use the [`data()`](https://docs.rs/volga/latest/volga/http/endpoints/args/sse/struct.Message.html#method.data) method as shown above. If you need to send structured data, such as JSON, use the [`json()`](https://docs.rs/volga/latest/volga/http/endpoints/args/sse/struct.Message.html#method.json) method, which accepts any type that implements the [`serde::Serialize`](https://docs.rs/serde/1.0.219/serde/ser/trait.Serialize.html) trait:
 
-```rust
+```rust compile-fragment
 use volga::http::sse::Message;
 use serde::Serialize;
 

--- a/docs/en/protocols-realtime/ws.md
+++ b/docs/en/protocols-realtime/ws.md
@@ -22,7 +22,7 @@ volga = { version = "...", features = ["http2", "ws"] }
 
 After updating `Cargo.toml` with the `ws` feature flag, you can implement a basic message handler using the [`map_msg()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_msg) method. The following example responds with a formatted string containing the received message:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -40,7 +40,7 @@ async fn main() -> std::io::Result<()> {
 
 This is a very simple example, to get more control over a particular connection you may choose another method - [`map_ws()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_ws).
 
-```rust
+```rust compile
 use volga::{App, ws::WebSocket};
 
 #[tokio::main]
@@ -100,7 +100,7 @@ This example sends a single message upon connection and logs incoming messages.
 
 For full control, for instance, to configure a connection or specify some sub-protocols, there is another method - [`map_conn()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_conn), you may use it like this:
 
-```rust
+```rust compile-fragment
 use volga::{App, ws::{WebSocketConnection, WebSocket}};
 
 #[tokio::main]

--- a/docs/en/reliability-observability/cancellation.md
+++ b/docs/en/reliability-observability/cancellation.md
@@ -4,7 +4,7 @@ If a long-running task needs to be canceled upon a remote client closing the con
 
 This is how it can be used:
 
-```rust
+```rust compile
 use std::time::Duration;
 use volga::{App, CancellationToken, ok};
 
@@ -30,7 +30,7 @@ async fn main() -> std::io::Result<()> {
 }
 ```
 More robust version with using [`tokio::select!`](https://docs.rs/tokio/latest/tokio/macro.select.html):
-```rust
+```rust compile
 use std::time::Duration;
 use volga::{App, CancellationToken, ok};
 

--- a/docs/en/reliability-observability/errors.md
+++ b/docs/en/reliability-observability/errors.md
@@ -5,7 +5,7 @@ Volga provides a global error handling mechanism that catches all [`Error`](http
 The function receives an [`Error`](https://docs.rs/volga/latest/volga/error/struct.Error.html) object and should return a response that implements the [`IntoResponse`](https://docs.rs/volga/latest/volga/http/response/into_response/trait.IntoResponse.html) trait.  
 
 ### Example:
-```rust
+```rust compile
 use volga::{App, error::Error, status};
 
 #[tokio::main]
@@ -42,7 +42,7 @@ To enable this functionality, ensure that the `problem-details` feature is activ
 volga = { version = "...", features = ["problem-details"] }
 ```
 Then, you may return the [`Problem`](https://docs.rs/volga/latest/volga/error/problem/struct.Problem.html) from request handler:
-```rust
+```rust compile
 use volga::{App, error::Problem};
 use serde::Serialize;
 
@@ -99,7 +99,7 @@ Content-Type: application/problem+json
 ## Global Error Handling With Problem Details
 
 Moreover, you can combine the [`Problem`](https://docs.rs/volga/latest/volga/error/problem/struct.Problem.html) with [`map_err`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_err) by using the [`use_problem_details()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_problem_details) method:
-```rust
+```rust compile
 use volga::{App, error::Error};
 
 #[tokio::main]

--- a/docs/en/reliability-observability/graceful-shutdown.md
+++ b/docs/en/reliability-observability/graceful-shutdown.md
@@ -1,0 +1,111 @@
+# Graceful Shutdown
+
+Volga always shuts down gracefully on an OS signal — `Ctrl+C` and `SIGTERM` on Unix, and their equivalents on Windows. When the signal arrives the listener stops accepting new connections, in-flight requests are allowed to finish, and only then does [`run()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.run) return.
+
+Starting with **v0.9.3**, the same shutdown can be triggered from your own code with a [`ShutdownHandle`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html) — for an admin endpoint, a watchdog, a lease that expired, or a worker that finished the job the process was started for.
+
+## Creating an App with a Handle
+
+[`App::with_shutdown()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_shutdown) returns an app paired with a fresh handle:
+
+```rust
+use std::time::Duration;
+use volga::App;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let (app, shutdown) = App::with_shutdown();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        shutdown.shutdown();
+    });
+
+    app.run().await
+}
+```
+
+The handle is cheap to clone and can be handed anywhere; calling [`shutdown()`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html#method.shutdown) from any clone starts the same graceful shutdown. It **composes** with the built-in signal handler rather than replacing it — whichever fires first wins.
+
+## Registering an External Handle
+
+If the handle is owned elsewhere — created during startup, stored in your application state, shared with background tasks — register it on an existing app with [`with_shutdown_signal()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_shutdown_signal):
+
+```rust
+use volga::{App, ShutdownHandle};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let handle = ShutdownHandle::new();
+    let app = App::new().with_shutdown_signal(handle.clone());
+
+    // `handle` can now live in your state, a supervisor, a CLI command...
+    app.run().await
+}
+```
+
+A [`ShutdownHandle`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html) is built on Tokio's [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html), so it can also adopt a token you already have with [`ShutdownHandle::from_token()`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html#method.from_token) (or the equivalent `From<CancellationToken>`), which lets the server join a cancellation tree the rest of your process already uses.
+
+Two more methods let you observe the state rather than trigger it:
+
+* [`is_shutdown_requested()`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html#method.is_shutdown_requested) — whether a shutdown has been requested;
+* [`cancelled()`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html#method.cancelled) — a future that resolves when it is, so background tasks can wind down with the server.
+
+## Shutting Down on a Future
+
+[`shutdown_on()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.shutdown_on) triggers a graceful shutdown when the given future resolves — useful for anything that already signals itself asynchronously: a `oneshot` channel, an external watchdog, a config-reload notification, a lease renewal that gave up.
+
+```rust
+use volga::App;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+    let app = App::new()
+        .bind("127.0.0.1:7878")
+        .shutdown_on(async move { let _ = rx.await; });
+
+    // sending on `tx` later triggers a graceful shutdown
+    app.run().await
+}
+```
+
+Multiple [`shutdown_on()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.shutdown_on) calls compose: any of the registered futures resolving triggers the shutdown, and all of them compose with the OS signal handler and with a [`ShutdownHandle`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html) registered earlier. If no handle was registered, one is created internally.
+
+::: tip
+The future is spawned onto the Tokio runtime when the app starts, so [`shutdown_on()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.shutdown_on) is safe to call before any runtime exists — including in front of [`run_blocking()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.run_blocking).
+:::
+
+## Shutting Down from a Handler
+
+Since the handle is just a clonable value, injecting it through [dependency injection](/volga-docs/en/advanced-patterns/di.html) gives you an administrative shutdown endpoint:
+
+```rust
+use volga::{App, ShutdownHandle, di::Dc, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let handle = ShutdownHandle::new();
+
+    let mut app = App::new().with_shutdown_signal(handle.clone());
+    app.add_singleton(handle);
+
+    app.map_post("/admin/shutdown", |handle: Dc<ShutdownHandle>| async move {
+        handle.shutdown();
+        ok!("shutting down")
+    });
+
+    app.run().await
+}
+```
+
+The response is still delivered: the request that asked for the shutdown is in flight, and in-flight requests are what a graceful shutdown waits for.
+
+::: warning
+Guard an endpoint like this with [authentication and authorization](/volga-docs/en/security-access/auth.html) — it stops the server for everyone.
+:::
+
+## Shutdown and Request Cancellation
+
+The two are related but distinct. A shutdown lets in-flight requests **finish**; [request cancellation](/volga-docs/en/reliability-observability/cancellation.html) fires when a *client* disappears mid-request. A long-running handler should observe both: the per-request [`CancellationToken`](https://docs.rs/volga/latest/volga/app/endpoints/args/cancellation_token/type.CancellationToken.html) so it stops working for a client that left, and the shutdown handle so it does not hold the process open past the point of no return.

--- a/docs/en/reliability-observability/graceful-shutdown.md
+++ b/docs/en/reliability-observability/graceful-shutdown.md
@@ -8,7 +8,7 @@ Starting with **v0.9.3**, the same shutdown can be triggered from your own code 
 
 [`App::with_shutdown()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_shutdown) returns an app paired with a fresh handle:
 
-```rust
+```rust compile
 use std::time::Duration;
 use volga::App;
 
@@ -31,7 +31,7 @@ The handle is cheap to clone and can be handed anywhere; calling [`shutdown()`](
 
 If the handle is owned elsewhere — created during startup, stored in your application state, shared with background tasks — register it on an existing app with [`with_shutdown_signal()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_shutdown_signal):
 
-```rust
+```rust compile
 use volga::{App, ShutdownHandle};
 
 #[tokio::main]
@@ -55,7 +55,7 @@ Two more methods let you observe the state rather than trigger it:
 
 [`shutdown_on()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.shutdown_on) triggers a graceful shutdown when the given future resolves — useful for anything that already signals itself asynchronously: a `oneshot` channel, an external watchdog, a config-reload notification, a lease renewal that gave up.
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -81,7 +81,7 @@ The future is spawned onto the Tokio runtime when the app starts, so [`shutdown_
 
 Since the handle is just a clonable value, injecting it through [dependency injection](/volga-docs/en/advanced-patterns/di.html) gives you an administrative shutdown endpoint:
 
-```rust
+```rust compile
 use volga::{App, ShutdownHandle, di::Dc, ok};
 
 #[tokio::main]

--- a/docs/en/reliability-observability/tracing.md
+++ b/docs/en/reliability-observability/tracing.md
@@ -13,7 +13,7 @@ tracing-subscriber = "0.3"
 ```
 
 ## Basic configuration
-```rust
+```rust compile
 use volga::{App, tracing::TracingConfig};
 use tracing::trace;
 use tracing_subscriber::prelude::*;
@@ -52,7 +52,7 @@ Then, if you'll hit the `GET http://127.0.0.1:7878/tracing` endpoint multiple ti
 ## Enabling tracing middleware
 With the above example, however, if you check the response headers, you won't find anything related to span id, etc.
 To include it you may want to leverage the [`with_tracing()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_tracing) or [`set_tracing`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.set_tracing) methods that enable the low-level middleware that adds this header.
-```rust
+```rust compile
 use volga::{App, tracing::TracingConfig};
 use tracing::trace;
 use tracing_subscriber::prelude::*;

--- a/docs/en/requests-responses/body.md
+++ b/docs/en/requests-responses/body.md
@@ -13,7 +13,7 @@ tokio = { version = "...", features = ["full"] }
 http-body-util = "0.1"
 ```
 
-```rust
+```rust compile
 use http_body_util::BodyExt;
 use volga::{App, HttpBody, ok};
 
@@ -44,7 +44,7 @@ The body limit still applies: by default Volga rejects request bodies over 5 MB.
 
 [`HttpBody`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html) can also be returned, which makes a pass-through handler a matter of moving it into the response — nothing is buffered:
 
-```rust
+```rust compile
 use volga::{App, HttpBody, HttpResponse, headers::ContentType};
 
 #[tokio::main]
@@ -73,7 +73,7 @@ tokio = { version = "...", features = ["full"] }
 futures-util = "0.3"
 ```
 
-```rust
+```rust compile
 use futures_util::StreamExt;
 use volga::{App, http::HttpBodyStream, ok};
 

--- a/docs/en/requests-responses/body.md
+++ b/docs/en/requests-responses/body.md
@@ -1,0 +1,112 @@
+# Raw Request Body
+
+Most handlers take a typed extractor — [`Json<T>`](/volga-docs/en/requests-responses/json-payload.html), [`Form<T>`](/volga-docs/en/requests-responses/form.html), [`Multipart`](/volga-docs/en/requests-responses/multipart.html) — and never touch the bytes underneath. When you do need them (a proxy, a webhook whose signature covers the exact payload, a custom wire format), Volga exposes the body itself.
+
+## Reading the Body as Bytes
+
+Starting with **v0.9.4**, [`HttpBody`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html) is an extractor — take it as a handler argument to get the raw request body:
+
+```toml
+[dependencies]
+volga = { version = "..." }
+tokio = { version = "...", features = ["full"] }
+http-body-util = "0.1"
+```
+
+```rust
+use http_body_util::BodyExt;
+use volga::{App, HttpBody, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_post("/raw", |body: HttpBody| async move {
+        let bytes = body.collect().await?.to_bytes();
+        ok!(format!("received {} bytes", bytes.len()))
+    });
+
+    app.run().await
+}
+```
+
+Collecting the body needs the [`Body`](https://docs.rs/http-body/latest/http_body/trait.Body.html) trait methods, which come from the [`BodyExt`](https://docs.rs/http-body-util/latest/http_body_util/trait.BodyExt.html) extension trait of `http-body-util` — Volga does not re-export it.
+
+::: warning
+The request body is a stream that can be consumed only once, so [`HttpBody`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html) cannot be combined with another body extractor in the same handler. Extractors that read only the request head — [`Path<T>`](/volga-docs/en/getting-started/route-params.html), [`Query<T>`](/volga-docs/en/getting-started/query-params.html), [`HttpHeaders`](/volga-docs/en/requests-responses/headers.html), [`Dc<T>`](/volga-docs/en/advanced-patterns/di.html) — combine with it freely.
+:::
+
+::: tip
+The body limit still applies: by default Volga rejects request bodies over 5 MB. Configure it with [`with_body_limit()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_body_limit) or lift it entirely with [`without_body_limit()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.without_body_limit).
+:::
+
+## Passing the Body Through
+
+[`HttpBody`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html) can also be returned, which makes a pass-through handler a matter of moving it into the response — nothing is buffered:
+
+```rust
+use volga::{App, HttpBody, HttpResponse, headers::ContentType};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_post("/trace", |body: HttpBody| async move {
+        HttpResponse::builder()
+            .status(200)
+            .header(ContentType::multipart_form_data("X-BOUNDARY"))
+            .body(body)
+    });
+
+    app.run().await
+}
+```
+
+## Streaming the Body
+
+To process the body as it arrives instead of collecting it, take [`HttpBodyStream`](https://docs.rs/volga/latest/volga/http/body/type.HttpBodyStream.html) — a [`ByteStream`](https://docs.rs/volga/latest/volga/http/endpoints/args/byte_stream/struct.ByteStream.html) over the request body, which implements [`Stream<Item = Result<Bytes, Error>>`](https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html):
+
+```toml
+[dependencies]
+volga = { version = "..." }
+tokio = { version = "...", features = ["full"] }
+futures-util = "0.3"
+```
+
+```rust
+use futures_util::StreamExt;
+use volga::{App, http::HttpBodyStream, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_post("/count", |mut stream: HttpBodyStream| async move {
+        let mut total = 0;
+        while let Some(chunk) = stream.next().await {
+            total += chunk?.len();
+        }
+        ok!(format!("received {total} bytes"))
+    });
+
+    app.run().await
+}
+```
+
+Use this for bodies you would rather not hold in memory at once — hashing an upload, forwarding chunks to storage, parsing a line-delimited stream.
+
+## Building a Body
+
+The same type constructs response bodies, which is what the [`ok!`](https://docs.rs/volga/latest/volga/macro.ok.html) family of macros does under the hood:
+
+| Constructor | Produces |
+|---|---|
+| [`HttpBody::full`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.full) | a complete in-memory body from anything convertible into `Bytes` |
+| [`HttpBody::empty`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.empty) | an empty body |
+| [`HttpBody::json`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.json) / [`form`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.form) | a serialized JSON or form body |
+| [`HttpBody::file`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.file) | a streaming body over an open file |
+| [`HttpBody::stream`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.stream) / [`stream_bytes`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.stream_bytes) | a streaming body over any `Stream` |
+
+## Examples
+
+You can find a raw body pass-through in the [multipart example](https://github.com/RomanEmreis/volga/blob/main/examples/multipart/src/main.rs).

--- a/docs/en/requests-responses/cookie.md
+++ b/docs/en/requests-responses/cookie.md
@@ -22,7 +22,7 @@ For signed or private cookies, see the [Signed & Private Cookies](#signed--priva
 
 Here's how to create and read cookies:
 
-```rust
+```rust compile
 use volga::{
     App, HttpResult,
     http::Cookies,
@@ -126,7 +126,7 @@ volga = { version = "...", features = ["cookie-full", "di"] }
 
 Signed and private cookies require secret keys, provided via DI:
 
-```rust
+```rust compile-fragment
 use volga::http::SignedKey;
 
 app.add_singleton(SignedKey::generate()); // or use your own key
@@ -134,7 +134,7 @@ app.add_singleton(SignedKey::generate()); // or use your own key
 
 Alternatively, for private cookies:
 
-```rust
+```rust compile-fragment
 use volga::http::PrivateKey;
 
 app.add_singleton(PrivateKey::generate()); // or use your own key

--- a/docs/en/requests-responses/files.md
+++ b/docs/en/requests-responses/files.md
@@ -7,7 +7,7 @@ Volga's [`file!`](https://docs.rs/volga/latest/volga/macro.file.html) macro faci
 
 ### Using the `file!` macro
 The `file!` macro provides a short syntax for initiating file downloads:
-```rust
+```rust compile
 use volga::{App, file};
 use tokio::fs::File;
 
@@ -34,7 +34,7 @@ For file uploads, Volga has [`save()`](https://docs.rs/volga/latest/volga/http/e
 
 ### Example of File Upload
 This example demonstrates how to set up a route to handle file uploads:
-```rust
+```rust compile
 use volga::{App, File};
 
 #[tokio::main]
@@ -60,7 +60,7 @@ volga = { version = "...", features = ["multipart"] }
 ```
 ### Example of Multipart file uploading
 This example demonstrates how to upload multiple files:
-```rust
+```rust compile
 use volga::{App, Multipart};
 
 #[tokio::main]

--- a/docs/en/requests-responses/form.md
+++ b/docs/en/requests-responses/form.md
@@ -4,7 +4,7 @@ Volga can help to easily handle a form data in your web applications, both for i
 
 ## Receiving Form Data
 To accept a form data body in a request and deserialize it into a strongly-typed entity, use the [`Form<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/form/struct.Form.html) struct. Where `T` should be a deserializable struct or [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html). For the struct ensure it derives from [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) from [serde](https://crates.io/crates/serde):
-```rust
+```rust compile
 use volga::{App, Form, ok};
 use serde::Deserialize;
  
@@ -38,7 +38,7 @@ Similarly to [`Json<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/
 
 ## Sending Form Data
 To send a form data response you can leverage the [`form!`](https://docs.rs/volga/latest/volga/macro.form.html) macro:
-```rust
+```rust compile
 use volga::{App, Form, form};
 use serde::Serialize;
  
@@ -65,7 +65,7 @@ async fn main() -> std::io::Result<()> {
 ```
 Alternatively, by specifying a [`Form<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/form/struct.Form.html) as a return type you can return a struct of your type directly, thanks to [`IntoResponse`](https://docs.rs/volga/latest/volga/http/response/into_response/trait.IntoResponse.html) trait:
 
-```rust
+```rust compile
 use volga::{App, Form};
 use serde::Serialize;
  

--- a/docs/en/requests-responses/headers.md
+++ b/docs/en/requests-responses/headers.md
@@ -7,7 +7,7 @@ Volga makes it possible to easily manage HTTP headers, both for reading from req
 To read headers from an incoming request, you can use [`Header<T>`](https://docs.rs/volga/latest/volga/headers/header/struct.Header.html) to extract a specific header from the request or [`HttpHeaders`](https://docs.rs/volga/latest/volga/headers/header/struct.HttpHeaders.html) to get the full [`HeaderMap`](https://docs.rs/http/latest/http/header/struct.HeaderMap.html) read-only snapshot.
 
 ### Using `Header<T>`
-```rust
+```rust compile
 use volga::{App, ok};
 use volga::headers::{Header, ContentType};
 
@@ -65,7 +65,7 @@ Received x-api-key: 123-321
 ```
 ### Simplifying custom headers handling with `headers!` macro
 The code above can be simplified by using the [`headers!`](https://docs.rs/volga/latest/volga/macro.headers.html) macro, especially if you need to add multiple headers:
-```rust
+```rust compile
 use volga::{App, ok};
 use volga::headers::{
     Header,
@@ -97,7 +97,7 @@ Received x-api-key: 123-321; correlation-id: 456-654
 
 ### Using `HttpHeaders`
 The same can be achieved also by using [`HttpHeaders`](https://docs.rs/volga/latest/volga/headers/header/struct.HttpHeaders.html) struct:
-```rust
+```rust compile
 use volga::{App, ok};
 use volga::headers::HttpHeaders;
 

--- a/docs/en/requests-responses/json-payload.md
+++ b/docs/en/requests-responses/json-payload.md
@@ -4,7 +4,7 @@ Volga simplifies the process of dealing with JSON data in your web applications,
 
 ## Receiving JSON Data
 To accept a JSON body in a request and deserialize it into a strongly-typed entity, use the [`Json<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/json/struct.Json.html) struct. Where `T` should be a deserializable struct, so ensure it derives from [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) from [serde](https://crates.io/crates/serde):
-```rust
+```rust compile
 use volga::{App, Json, ok};
 use serde::Deserialize;
  
@@ -38,7 +38,7 @@ You can wrap your struct fields into [`Option<T>`](https://doc.rust-lang.org/std
 
 ## Sending JSON Responses
 To send responses as JSON, Volga provides the [`ok!`](https://docs.rs/volga/latest/volga/macro.ok.html) macro
-```rust
+```rust compile
 use volga::{App, ok};
 use serde::Serialize;
  
@@ -87,7 +87,7 @@ async fn main() -> std::io::Result<()> {
 ```
 ### Using Status with JSON
 You can also include HTTP status codes in your JSON responses using the [`status!`](https://docs.rs/volga/latest/volga/macro.status.html) macro:
-```rust
+```rust compile
 use volga::{App, status};
 use serde::Serialize;
  

--- a/docs/en/requests-responses/multipart.md
+++ b/docs/en/requests-responses/multipart.md
@@ -17,7 +17,7 @@ volga = { version = "...", features = ["multipart"] }
 ## Returning a Multipart Response
 
 The simplest way to build an outgoing multipart is [`Multipart::from_parts`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Multipart.html#method.from_parts), which accepts any `IntoIterator<Item = Part>`:
-```rust
+```rust compile
 use volga::{App, Multipart, multipart::Part};
 
 #[tokio::main]
@@ -53,7 +53,7 @@ The response gets a `Content-Type: multipart/form-data; boundary=...` header wit
 Each builder has a fallible `try_*` counterpart (`try_text`, `try_bytes`, `try_file`, `try_stream`, `try_with_disposition`) — the static-input constructors panic on invalid header bytes, and the `try_*` variants should be preferred when the name or filename comes from untrusted input.
 
 A typical mixed example combining a text field and an in-memory file:
-```rust
+```rust compile
 use bytes::Bytes;
 use volga::{App, Multipart, multipart::Part};
 
@@ -75,7 +75,7 @@ async fn main() -> std::io::Result<()> {
 ## Streaming Parts
 
 When a part's body is large or produced incrementally, use [`Part::stream`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Part.html#method.stream) to send it without buffering. The body must be a `Stream<Item = Result<Bytes, volga::error::Error>>`:
-```rust
+```rust compile
 use bytes::Bytes;
 use futures_util::{StreamExt, stream};
 use volga::{App, Multipart, multipart::Part};
@@ -110,7 +110,7 @@ If the parts themselves are produced lazily (e.g. enumerating files, computing b
 ## Choosing a Subtype
 
 By default, outgoing multiparts use the `multipart/form-data` subtype. To switch to `mixed`, `byteranges`, or any other RFC 2046 subtype, call [`Multipart::with_subtype`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Multipart.html#method.with_subtype):
-```rust
+```rust compile
 use bytes::Bytes;
 use volga::{App, Multipart, multipart::{MultipartSubtype, Part}};
 use volga::headers::{ContentType, HeaderName, HeaderValue};
@@ -150,7 +150,7 @@ The supported variants are:
 ## Customizing the Boundary
 
 The boundary is generated automatically and is RFC 2046 §5.1.1 compliant. To pin it (useful in tests or when interoperating with a strict client), use [`Multipart::with_boundary`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Multipart.html#method.with_boundary). It validates the input and returns an error if the boundary is malformed:
-```rust
+```rust compile
 use volga::{App, Multipart, multipart::Part};
 
 #[tokio::main]
@@ -169,7 +169,7 @@ async fn main() -> std::io::Result<()> {
 ## Forwarding an Incoming Multipart
 
 When you need to proxy or forward an incoming multipart body back to a client, use [`Multipart::into_outgoing`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Multipart.html#method.into_outgoing). It re-encodes the request multipart as a streaming outgoing one — each field becomes a `Part` with a streaming body:
-```rust
+```rust compile
 use volga::{App, Multipart};
 
 #[tokio::main]

--- a/docs/en/security-access/auth.md
+++ b/docs/en/security-access/auth.md
@@ -210,7 +210,7 @@ This secret is used to sign the token during generation and to verify the signat
 
 Rather than configuring a static key, a resource server can validate bearer tokens against an OAuth 2.1 / OIDC issuer's published keys — no shared secret required. Describe the issuer with [`with_oauth(...)`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth) and opt in with [`use_oauth()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth):
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .with_bearer_auth(|auth| auth.with_aud(["https://api.example.com"]))
     .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"));

--- a/docs/en/security-access/auth.md
+++ b/docs/en/security-access/auth.md
@@ -156,6 +156,8 @@ let mut app = App::new()
 
 ::: info
 `EncodingKey`, `DecodingKey`, and `Algorithm` are now native Volga types (no longer re-exported from `jsonwebtoken`). Import paths remain the same (`volga::auth::{EncodingKey, DecodingKey}`), but `jsonwebtoken::ErrorKind` is no longer available — use the PEM / base64 / secret / env / file constructors provided by Volga instead. Token validation settings live on [`BearerAuthConfig`](https://docs.rs/volga/latest/volga/auth/bearer/struct.BearerAuthConfig.html); the previous `BearerTokenService::validation()` accessor has been removed.
+
+Since **v0.9.8**, `volga::auth::Algorithm` is a re-export of [`JwsAlgorithm`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/enum.JwsAlgorithm.html) from `volga-oauth-core` — the variants, the `HS256` default and the behaviour are unchanged, but the type is now shared with the client crates, so a `private_key_jwt` assertion and a bearer token the server issues are described in one vocabulary. It is also re-exported from `volga::auth::oauth`, where it can be named without the `jwt-auth` feature.
 :::
 
 ### JWT Usage

--- a/docs/en/security-access/dpop.md
+++ b/docs/en/security-access/dpop.md
@@ -1,0 +1,161 @@
+# DPoP — Sender-Constrained Tokens
+
+A bearer token is a password: whoever holds it may use it. DPoP (RFC 9449) binds a token to a key the client holds, and every request carries a freshly signed proof of possession — so a token stolen from a log, a proxy or a compromised store is worth nothing without the key.
+
+Available since **v0.9.8** behind the `dpop` feature of `volga-oauth-client`:
+
+```toml
+[dependencies]
+volga-oauth-client = { version = "...", features = ["dpop"] }
+```
+
+::: info
+The feature is off by default because signing is the only part of the crate that needs a JWS backend. It is independent of `private-key-jwt`: a client credential says **who asked** for a token, a DPoP proof says **who holds** it, and one request may carry both.
+:::
+
+## The Key
+
+[`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html) is the key plus the nonce state of the servers it talks to. [`generate()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.generate) mints a throwaway `ES256` key — the algorithm every DPoP implementation supports:
+
+```rust
+use volga_oauth_client::{ClientError, Dpop, OAuthClient};
+
+fn build() -> Result<(), ClientError> {
+    let dpop = Dpop::generate()?;
+
+    let client = OAuthClient::new("my-client")
+        .with_secret("s3cret")
+        .with_dpop(dpop.clone());
+
+    // the same key protects the resource requests made with its tokens
+    let jkt = dpop.thumbprint();
+    Ok(())
+}
+```
+
+The usual lifetime is **one key per session**, not one per process — losing it costs nothing beyond the tokens bound to it, which cannot be used without it anyway. [`generate_with`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.generate_with) also does `ES384` and `EdDSA`; RSA keys are far too slow to generate per session and have to be loaded instead.
+
+For a key that outlives the process — one whose thumbprint a resource has already been told about — use [`from_pem`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.from_pem) or [`from_pem_file`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.from_pem_file), which take the public half explicitly and verify the two halves against each other with one signature at construction, so a mismatched pair is refused there rather than failing remotely on every request it would ever sign.
+
+Cloning a [`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html) shares the key **and** the nonces, so the client and the code making resource requests with its tokens stay in step.
+
+## Obtaining Bound Tokens
+
+[`with_dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.with_dpop) puts a proof on every token request, whichever grant sends it — Authorization Code, [client credentials, JWT bearer or token exchange](/volga-docs/en/security-access/machine-to-machine.html). Everything else is handled for you:
+
+* the algorithm is checked against `dpop_signing_alg_values_supported` before the request leaves;
+* the authorization request names the key in `dpop_jkt` (RFC 9449 §10), binding the code to it, so a stolen code cannot be redeemed by anyone else;
+* a `use_dpop_nonce` refusal (§8.2) is answered by repeating the request exactly once with the nonce that refusal demanded;
+* the tokens come back as `token_type: DPoP`.
+
+```rust
+use volga_oauth_client::{AuthorizationServerMetadata, ClientError, Dpop, OAuthClient};
+
+async fn tokens(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
+    let dpop = Dpop::generate()?;
+
+    let tokens = OAuthClient::new("my-service")
+        .with_secret("s3cret")
+        .with_dpop(dpop.clone())
+        .client_credentials(metadata)
+        .with_scopes(["inventory:read"])
+        .send()
+        .await?;
+
+    assert!(tokens.is_dpop());
+    assert_eq!(tokens.dpop_jkt.as_deref(), Some(dpop.thumbprint()));
+    Ok(())
+}
+```
+
+::: warning
+A token that does **not** come back as `DPoP` is refused rather than handed to the caller and the token store as an unbound credential — a server without DPoP support simply ignores the proof, and silently accepting a bearer token there would give up the binding the key exists for.
+:::
+
+[`TokenSet::is_dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html#method.is_dpop) and [`TokenSet::dpop_jkt`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html#structfield.dpop_jkt) report the binding recorded by the client that obtained the token. A [`TokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.TokenStore.html) outlives a process while a generated key does not, so a stored entry is checked against the key in hand before it is served: an entry bound to a key this client cannot prove possession of is dead weight however unexpired it looks. That is not an error — it is a stale cache, so the entry is evicted and a token that fits is obtained instead.
+
+## Protecting Resource Requests
+
+Requests to the resource stay yours to make: this crate mints proofs and owns the nonce state, it does not become an HTTP client for you. [`authorize`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize) fills in both headers — the `Authorization: DPoP <token>` credential and the `DPoP` proof covering it:
+
+```rust
+use http::{HeaderMap, Method};
+use volga_oauth_client::{ClientError, Dpop, TokenSet};
+
+fn protect(dpop: &Dpop, url: &str, tokens: &TokenSet) -> Result<(), ClientError> {
+    let mut headers = HeaderMap::new();
+    let sent = dpop.authorize(&mut headers, &Method::GET, url, tokens)?;
+
+    // ...send the request with these headers
+    Ok(())
+}
+```
+
+The proof carries `typ: dpop+jwt`, the public key **by value** in the `jwk` header (never by `kid`, unlike a client assertion), the `htm` / `htu` / `iat` / `jti` claims, and `ath` — the hash of the access token — on every request that presents one. `htu` drops the query and fragment.
+
+::: warning
+[`authorize`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize) refuses a token this key cannot present — a bearer token, or one whose recorded binding names a different key — *before* the request, rather than letting the resource refuse it on every one.
+:::
+
+Two lower-level pieces are available when `authorize` is not the right shape:
+
+* [`proof`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.proof) builds a proof by hand — [`with_access_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DpopProof.html#method.with_access_token), [`with_nonce`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DpopProof.html#method.with_nonce), then [`sign`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DpopProof.html#method.sign);
+* [`thumbprint`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.thumbprint) is the `jkt` (RFC 7638) an authorization server binds a token to — the value to hand to a resource that pins keys out of band.
+
+## Nonces
+
+A server may demand that proofs carry a nonce of its choosing. The token endpoint's round is handled internally; the resource's round is yours, because you send those requests:
+
+```rust
+use http::{HeaderMap, Method};
+use volga_oauth_client::{ClientError, Dpop, TokenSet};
+
+fn with_retry(dpop: &Dpop, url: &str, tokens: &TokenSet) -> Result<(), ClientError> {
+    let mut headers = HeaderMap::new();
+    let sent = dpop.authorize(&mut headers, &Method::GET, url, tokens)?;
+
+    // ...send the request; then, given a `use_dpop_nonce` refusal:
+    let response_headers = HeaderMap::new();
+    if let Some(demanded) = dpop.accept_nonce(url, &response_headers)
+        && Some(demanded.as_str()) != sent.as_deref()
+    {
+        dpop.authorize_with_nonce(&mut headers, &Method::GET, url, tokens, &demanded)?;
+        // ...and send it once more
+    }
+
+    Ok(())
+}
+```
+
+* [`authorize`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize) returns the nonce the proof it just signed actually carried — resolving and signing are one step, which a separate lookup could not promise while other requests to the same origin are in flight.
+* [`accept_nonce`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.accept_nonce) adopts the nonce of any response and returns it.
+* [`authorize_with_nonce`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize_with_nonce) puts exactly that nonce in the retry, whatever the shared state has moved on to in the meantime.
+
+::: info
+Nonces are remembered per origin **and** per namespace: a token endpoint (§8) and a protected resource (§9) issue unrelated sequences even when one host serves both, so the origin alone cannot be the key.
+:::
+
+## Reading a DPoP Challenge
+
+A DPoP-protected resource answers `401` with a `WWW-Authenticate: DPoP ...` challenge whose `error` and `error_description` are the RFC 6750 ones. Since **v0.9.8**, [`BearerChallenge::parse_scheme`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.BearerChallenge.html#method.parse_scheme) reads a challenge under any scheme:
+
+```rust
+use volga_oauth_client::{BearerChallenge, OAuthError, auth_scheme};
+
+fn read(header: &str) -> Result<(), OAuthError> {
+    let challenge = BearerChallenge::parse_scheme(header, auth_scheme::DPOP)?;
+    Ok(())
+}
+```
+
+[`with_scheme`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.BearerChallenge.html#method.with_scheme) and [`scheme`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.BearerChallenge.html#method.scheme) render and report it, so a parsed challenge re-renders under the scheme it arrived with. `parse` is this method with `auth_scheme::BEARER`.
+
+The two registered DPoP error codes are modelled as well: `OAuthErrorCode::UseDpopNonce` and `OAuthErrorCode::InvalidDpopProof` (RFC 9449 §7.1), which used to surface as `Other`.
+
+::: warning
+Three **v0.9.8** changes are worth checking when upgrading:
+
+* `OAuthErrorCode` is `#[non_exhaustive]`, so nothing stops compiling — but code that matched the two DPoP codes as `Other(..)` no longer matches them. The wire form, `as_str` and the serde representation are unchanged.
+* [`TokenSet`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html) gained the `dpop_jkt` field, so code constructing one with a struct literal has to name it (`None` for a bearer token). The wire form is unchanged for anything that carries no binding, so a persisted entry written by an earlier version still reads back.
+* [`ClientAuthMethod`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientAuthMethod.html) is no longer `Copy` — the new `PrivateKeyJwt` variant carries a signing key. It stays `Clone`, `Debug`, `PartialEq` and `Eq`.
+:::

--- a/docs/en/security-access/dpop.md
+++ b/docs/en/security-access/dpop.md
@@ -17,7 +17,7 @@ The feature is off by default because signing is the only part of the crate that
 
 [`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html) is the key plus the nonce state of the servers it talks to. [`generate()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.generate) mints a throwaway `ES256` key — the algorithm every DPoP implementation supports:
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, Dpop, OAuthClient};
 
 fn build() -> Result<(), ClientError> {
@@ -48,7 +48,7 @@ Cloning a [`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/
 * a `use_dpop_nonce` refusal (§8.2) is answered by repeating the request exactly once with the nonce that refusal demanded;
 * the tokens come back as `token_type: DPoP`.
 
-```rust
+```rust compile
 use volga_oauth_client::{AuthorizationServerMetadata, ClientError, Dpop, OAuthClient};
 
 async fn tokens(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
@@ -78,7 +78,7 @@ A token that does **not** come back as `DPoP` is refused rather than handed to t
 
 Requests to the resource stay yours to make: this crate mints proofs and owns the nonce state, it does not become an HTTP client for you. [`authorize`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize) fills in both headers — the `Authorization: DPoP <token>` credential and the `DPoP` proof covering it:
 
-```rust
+```rust compile
 use http::{HeaderMap, Method};
 use volga_oauth_client::{ClientError, Dpop, TokenSet};
 
@@ -106,7 +106,7 @@ Two lower-level pieces are available when `authorize` is not the right shape:
 
 A server may demand that proofs carry a nonce of its choosing. The token endpoint's round is handled internally; the resource's round is yours, because you send those requests:
 
-```rust
+```rust compile
 use http::{HeaderMap, Method};
 use volga_oauth_client::{ClientError, Dpop, TokenSet};
 
@@ -139,7 +139,7 @@ Nonces are remembered per origin **and** per namespace: a token endpoint (§8) a
 
 A DPoP-protected resource answers `401` with a `WWW-Authenticate: DPoP ...` challenge whose `error` and `error_description` are the RFC 6750 ones. Since **v0.9.8**, [`BearerChallenge::parse_scheme`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.BearerChallenge.html#method.parse_scheme) reads a challenge under any scheme:
 
-```rust
+```rust compile
 use volga_oauth_client::{BearerChallenge, OAuthError, auth_scheme};
 
 fn read(header: &str) -> Result<(), OAuthError> {

--- a/docs/en/security-access/machine-to-machine.md
+++ b/docs/en/security-access/machine-to-machine.md
@@ -18,7 +18,7 @@ These grants need [client authentication](/volga-docs/en/security-access/oauth-c
 
 The plain machine-to-machine grant. There is no authorization request to carry scopes here, so they go on the token request itself — or are omitted, leaving the server to apply the client's default grant:
 
-```rust
+```rust compile
 use volga_oauth_client::{AuthorizationServerMetadata, ClientError, OAuthClient};
 
 async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
@@ -39,7 +39,7 @@ async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> 
 
 RFC 6749 §4.4.3 issues **no refresh token** for this grant, so there is nothing for [`OAuthClient::token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.token) to renew a stored token *with* — re-running the grant is the renewal. That is what [`ClientCredentialsRequest::token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.token) does: it serves the stored token while it is fresh and runs the grant again — with the same scopes and resource indicators — when it is not.
 
-```rust
+```rust compile
 use std::sync::Arc;
 use volga_oauth_client::{
     AuthorizationServerMetadata, ClientError, InMemoryTokenStore, OAuthClient,
@@ -72,7 +72,7 @@ The method **panics** when no [`TokenStore`](https://docs.rs/volga-oauth-client/
 
 Presents a JWT as an authorization grant. The assertion is supplied by the caller rather than minted here: it is what some other authority already issued — a workload identity token from the platform the client runs on, or an identity assertion obtained from a prior exchange.
 
-```rust
+```rust compile
 use volga_oauth_client::{AuthorizationServerMetadata, ClientError, OAuthClient};
 
 async fn run(
@@ -101,7 +101,7 @@ A failure here is final: the assertion is either accepted or it is not. Do not r
 
 Trades one token for another (RFC 8693) — the delegation and impersonation grant. `subject_token` represents the party the new token is requested for, and `subject_token_type` identifies what it is: one of the [`token_type`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/protocol/token_type/index.html) constants, or any URI the server understands.
 
-```rust
+```rust compile
 use volga_oauth_client::{
     AuthorizationServerMetadata, ClientError, OAuthClient, token_type,
 };

--- a/docs/en/security-access/machine-to-machine.md
+++ b/docs/en/security-access/machine-to-machine.md
@@ -1,0 +1,152 @@
+# Machine-to-Machine Grants
+
+The [Authorization Code flow](/volga-docs/en/security-access/oauth-client.html#authorization-code-pkce) exists to get a token *on behalf of a user*. Plenty of traffic has no user in it: a background worker calling an internal API, a job runner, a service that needs a token for itself. Since **v0.9.8**, `volga-oauth-client` drives the three grants for those cases, where the client is the subject.
+
+All three are builders on [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html), share the same [`with_scopes`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.with_scopes) / [`with_resource`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.with_resource) (RFC 8707) / [`with_param`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.with_param) options, and are sent with `send()`:
+
+| Method | Grant | Use it when |
+|---|---|---|
+| [`client_credentials`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.client_credentials) | RFC 6749 §4.4 | the service acts as itself, with its own credential |
+| [`jwt_bearer`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.jwt_bearer) | RFC 7523 §2.1 | some other authority already issued a JWT that vouches for it |
+| [`exchange_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.exchange_token) | RFC 8693 | one token has to be traded for another |
+
+::: tip
+These grants need [client authentication](/volga-docs/en/security-access/oauth-client.html#client-authentication) — a secret or a `private_key_jwt` key. A public client has nothing to present, and any sane server will refuse it.
+:::
+
+## Client Credentials
+
+The plain machine-to-machine grant. There is no authorization request to carry scopes here, so they go on the token request itself — or are omitted, leaving the server to apply the client's default grant:
+
+```rust
+use volga_oauth_client::{AuthorizationServerMetadata, ClientError, OAuthClient};
+
+async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
+    let client = OAuthClient::new("my-service").with_secret("s3cret");
+
+    let tokens = client
+        .client_credentials(metadata)
+        .with_scopes(["inventory:read"])
+        .with_resource("https://api.example.com")
+        .send()
+        .await?;
+
+    Ok(())
+}
+```
+
+### Holding a service token
+
+RFC 6749 §4.4.3 issues **no refresh token** for this grant, so there is nothing for [`OAuthClient::token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.token) to renew a stored token *with* — re-running the grant is the renewal. That is what [`ClientCredentialsRequest::token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.token) does: it serves the stored token while it is fresh and runs the grant again — with the same scopes and resource indicators — when it is not.
+
+```rust
+use std::sync::Arc;
+use volga_oauth_client::{
+    AuthorizationServerMetadata, ClientError, InMemoryTokenStore, OAuthClient,
+};
+
+async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
+    let client = OAuthClient::new("my-service")
+        .with_secret("s3cret")
+        .with_token_store(Arc::new(InMemoryTokenStore::new()));
+
+    // the first call requests, the rest are served from the store
+    // until the token nears its expiry
+    let tokens = client
+        .client_credentials(metadata)
+        .with_scopes(["inventory:read"])
+        .token("inventory")
+        .await?;
+
+    Ok(())
+}
+```
+
+::: warning
+A stored token whose lifetime the server never stated is re-requested rather than served: `expires_in` is only RECOMMENDED by RFC 6749 §5.1, and an unknown lifetime is no evidence of freshness. Against a server that omits it, this therefore runs the grant on every call — that grant is a single request, and a caller who would rather cache anyway can hold the [`TokenSet`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html) from [`send()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.send) under its own policy.
+
+The method **panics** when no [`TokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.TokenStore.html) is attached.
+:::
+
+## JWT Bearer
+
+Presents a JWT as an authorization grant. The assertion is supplied by the caller rather than minted here: it is what some other authority already issued — a workload identity token from the platform the client runs on, or an identity assertion obtained from a prior exchange.
+
+```rust
+use volga_oauth_client::{AuthorizationServerMetadata, ClientError, OAuthClient};
+
+async fn run(
+    metadata: &AuthorizationServerMetadata,
+    workload_jwt: &str,
+) -> Result<(), ClientError> {
+    let tokens = OAuthClient::new("my-workload")
+        .jwt_bearer(metadata, workload_jwt)
+        .with_scopes(["inventory:read"])
+        .send()
+        .await?;
+
+    Ok(())
+}
+```
+
+::: warning
+A failure here is final: the assertion is either accepted or it is not. Do not retry it and do not fall back to another grant type — fix the assertion instead. An `invalid_grant` means the assertion itself was rejected.
+:::
+
+::: info
+`jwt_bearer` and `private_key_jwt` both send a signed JWT and are easy to confuse. They answer different questions: the JWT bearer **grant** is *why* a token should be issued, a `private_key_jwt` **client assertion** is *who is asking*. One request can carry both.
+:::
+
+## Token Exchange
+
+Trades one token for another (RFC 8693) — the delegation and impersonation grant. `subject_token` represents the party the new token is requested for, and `subject_token_type` identifies what it is: one of the [`token_type`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/protocol/token_type/index.html) constants, or any URI the server understands.
+
+```rust
+use volga_oauth_client::{
+    AuthorizationServerMetadata, ClientError, OAuthClient, token_type,
+};
+
+async fn run(
+    idp: &AuthorizationServerMetadata,
+    resource_server: &AuthorizationServerMetadata,
+    id_token: &str,
+) -> Result<(), ClientError> {
+    let client = OAuthClient::new("my-app").with_secret("s3cret");
+
+    // exchange the user's ID token for an assertion the resource's
+    // authorization server accepts...
+    let exchanged = client
+        .exchange_token(idp, id_token, token_type::ID_TOKEN)
+        .with_requested_token_type(token_type::ID_JAG)
+        .with_audience("https://api.example.com")
+        .send()
+        .await?;
+
+    // ...and present it there as a JWT bearer grant
+    let tokens = client
+        .jwt_bearer(resource_server, &exchanged.token)
+        .send()
+        .await?;
+
+    Ok(())
+}
+```
+
+Unlike the other two, an exchange may hand back something that is **not** a bearer access token, so it answers with an [`ExchangedToken`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ExchangedToken.html) rather than a [`TokenSet`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html):
+
+* `issued_token_type` — what the server decided to issue;
+* [`is_bearer()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ExchangedToken.html#method.is_bearer) — whether it is usable as an `Authorization: Bearer` credential;
+* [`is_expired()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ExchangedToken.html#method.is_expired) / [`expires_within()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ExchangedToken.html#method.expires_within) — the same absolute expiry handling as a `TokenSet`.
+
+Besides the shared options, the request takes [`with_requested_token_type`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenExchangeRequest.html#method.with_requested_token_type), [`with_audience`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenExchangeRequest.html#method.with_audience) and [`with_actor_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenExchangeRequest.html#method.with_actor_token) (delegation, where the acting party is named alongside the subject).
+
+## What Is Refused Before the Network
+
+All three grants refuse a request rather than send one that cannot succeed. **Both** sides have to allow the grant:
+
+* the server has to list it in `grant_types_supported`;
+* a client built by [`from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration) has to have had it approved in the registration's `grant_types`.
+
+The registration check applies to the Authorization Code flow too — `authorization_request().build()` and `exchange_code` refuse it rather than redirect a user into a flow the client may not complete. An omitted `grant_types` means `authorization_code` alone (RFC 7591 §2); only a client that never went through a registration is unconstrained, and `refresh_token` is never refused.
+
+Both failures surface as `ClientError::Validation`, which is a clearer signal than the `unauthorized_client` the token endpoint would have answered with.

--- a/docs/en/security-access/oauth-client.md
+++ b/docs/en/security-access/oauth-client.md
@@ -5,8 +5,10 @@
 It provides three clients, all sharing the transport policy of [`ClientConfig`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientConfig.html) and the error model of [`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html):
 
 * [`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) — fetches Authorization Server Metadata (RFC 8414), Protected Resource Metadata (RFC 9728) and the OpenID Connect provider configuration.
-* [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) — the Authorization Code flow with mandatory PKCE, refresh tokens and resource indicators, plus token persistence.
+* [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) — the Authorization Code flow with mandatory PKCE, refresh tokens and resource indicators, plus token persistence. Since **v0.9.8** it also drives the grants that authenticate the *client itself* — see [Machine-to-Machine Grants](/volga-docs/en/security-access/machine-to-machine.html).
 * [`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) — Dynamic Client Registration (RFC 7591).
+
+Since **v0.9.8** the tokens they obtain can also be sender-constrained with [`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html) (RFC 9449) — see [DPoP](/volga-docs/en/security-access/dpop.html).
 
 ## Dependencies
 
@@ -21,8 +23,14 @@ volga-oauth-client = { version = "..." }
 |---|---|
 | `http1` (default) | HTTP/1.1 via hyper |
 | `http2` | HTTP/2 via hyper; negotiated through TLS ALPN when combined with `http1`, used exclusively (prior knowledge over plaintext) without it |
+| `private-key-jwt` | `private_key_jwt` client authentication (RFC 7523 §2.2) — a client assertion signed with the client's own key |
+| `dpop` | DPoP sender-constrained tokens (RFC 9449) |
 
-At least one of the two must be enabled.
+At least one of `http1` / `http2` must be enabled.
+
+::: info
+`private-key-jwt` and `dpop` are off by default because they are the only parts of the crate that need a JWS signing backend (`jsonwebtoken` on `aws-lc-rs`). Every grant, the secret-based authentication methods and public clients work without them.
+:::
 
 ## Discovery
 
@@ -108,13 +116,39 @@ The request builder accepts [`with_scopes`](https://docs.rs/volga-oauth-client/l
 Always verify the callback `state` with [`matches_state`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.matches_state) **before** exchanging the code — it is your CSRF defence.
 :::
 
+### Validating the callback
+
+Since **v0.9.6**, [`validate_callback`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.validate_callback) checks the whole callback at once — the `state` *and* the RFC 9207 `iss` parameter — and is the recommended replacement for a bare `matches_state`:
+
+```rust
+use volga_oauth_client::{AuthorizationRequest, AuthorizationServerMetadata, ClientError};
+
+fn check(
+    request: &AuthorizationRequest,
+    metadata: &AuthorizationServerMetadata,
+    state: &str,
+    iss: Option<&str>,
+) -> Result<(), ClientError> {
+    request.validate_callback(metadata, state, iss)?;
+    Ok(())
+}
+```
+
+`iss` is the callback's `iss` query parameter, or `None` when the response carried none. It must match the issuer whenever it is present, and it is **required** once the server advertises `authorization_response_iss_parameter_supported`.
+
+::: warning
+Without the `iss` check, a callback can be replayed from a *different* authorization server — the mix-up attack RFC 9207 exists to prevent. If your provider advertises the parameter, use [`validate_callback`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.validate_callback); [`matches_state`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.matches_state) remains for the `state`-only check.
+:::
+
 ### Transparent refresh
 
 [`token(key, &metadata)`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.token) reads the stored tokens and refreshes a stale access token behind the scenes. It returns `Ok(None)` when interactive authorization is required — nothing is stored, the entry has no refresh token, or the server rejected the refresh token (`invalid_grant`); in the latter cases the dead entry is removed from the store. You can also refresh explicitly with [`refresh`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.refresh).
 
-### Confidential clients
+## Client Authentication
 
-Without a secret the client acts as a **public client** (PKCE is the protection). Attach a secret to authenticate to the token endpoint:
+Without a credential the client acts as a **public client** (PKCE is the protection OAuth 2.1 prescribes). A confidential client authenticates to the token endpoint with one of three methods, and the choice applies to every grant it sends.
+
+### Shared secret
 
 ```rust
 use volga_oauth_client::{ClientAuthMethod, OAuthClient};
@@ -124,6 +158,58 @@ let client = OAuthClient::new("my-client")
     // `client_secret_basic` (default) or `client_secret_post`
     .with_auth_method(ClientAuthMethod::Post);
 ```
+
+### `private_key_jwt`
+
+Since **v0.9.8** (feature `private-key-jwt`), the client can authenticate with an assertion signed by its own key (RFC 7523 §2.2), so no shared secret ever leaves it:
+
+```rust
+use volga_oauth_client::{ClientError, JwsAlgorithm, OAuthClient, PrivateKeyJwt};
+
+fn build() -> Result<OAuthClient, ClientError> {
+    let key = PrivateKeyJwt::from_pem_file("/etc/secrets/client.pem", JwsAlgorithm::RS256)?
+        .with_key_id("2026-08");
+
+    Ok(OAuthClient::new("my-client").with_private_key_jwt(key))
+}
+```
+
+[`PrivateKeyJwt`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html) loads the key ([`from_pem`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.from_pem), [`from_pem_file`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.from_pem_file), [`from_der`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.from_der)) and carries the claims policy — [`with_key_id`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_key_id), [`with_lifetime`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_lifetime) (60 seconds by default) and [`with_audiences`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_audiences). A fresh assertion with a random `jti` is minted per token request, so a captured one is not replayable for long. Attaching it supersedes any [`with_secret`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.with_secret) — the assertion is the credential.
+
+::: warning
+Symmetric algorithms are refused: an HMAC secret the server already holds proves nothing about who signed. The algorithm is also checked against the server's `token_endpoint_auth_signing_alg_values_supported` when it advertises one.
+:::
+
+### Publishing the public key
+
+The authorization server verifies assertions with the public half of the key, which it either fetches from a `jwks_uri` or received inline at registration. [`with_public_jwk`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_public_jwk) attaches it and [`jwks()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.jwks) renders the document to publish:
+
+```rust
+use volga_oauth_client::{ClientError, JwsAlgorithm, PrivateKeyJwt, PublicJwk};
+
+fn publish(key: PrivateKeyJwt, public: PublicJwk) -> Result<(), ClientError> {
+    let key = key.with_public_jwk(public)?;
+
+    // serve this at your `jwks_uri`, or send it as the `jwks` member of a
+    // Dynamic Client Registration request
+    let document = key.jwks();
+    Ok(())
+}
+```
+
+[`PublicJwk`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/jwk/struct.PublicJwk.html) (RFC 7517, in `volga-oauth-core`) models **public** signing material exclusively — there is no way to represent the private members, and deserializing a document that carries them fails rather than silently dropping them. It also refuses combinations no verifier could act on: an RSA key declaring `ES256`, a P-384 key declaring `ES256`, a public key declaring an HMAC algorithm, or a curve that does not belong to the key type. `kid` and `alg` are filled in from the signing configuration, so the published document always agrees with what the assertions actually carry.
+
+::: info
+Supply the *public* key explicitly — the crate signs, it does not derive public keys from private ones. That is also what makes publishing the signing key by accident impossible.
+:::
+
+### What is checked before the request leaves
+
+Since **v0.9.8** the configured method is validated against `token_endpoint_auth_methods_supported` before a token request is sent: a method the server never announced would only earn an `invalid_client` over the network. Metadata listing no methods is not second-guessed — that is what a hand-built [`AuthorizationServerMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationServerMetadata.html) carries — but a *discovered* document always lists something, since RFC 8414 makes an omitted field mean `client_secret_basic`. A public client presents no credential and is never checked.
+
+::: info
+The registered wire identifiers both sides of the protocol agree on live in one place since **v0.9.8** — `volga_oauth_core::protocol`, as the `grant`, `client_auth`, `token_type` and `auth_scheme` constants, re-exported from both `volga::auth::oauth` and `volga_oauth_client`. A server advertises them in its metadata document and a client matches on them, so the two cannot drift.
+:::
 
 ## Token Store
 
@@ -174,6 +260,28 @@ async fn register() -> Result<(), ClientError> {
 
 For servers that do not allow open registration, attach an initial access token with [`with_initial_access_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html#method.with_initial_access_token).
 
+Two [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientMetadata.html) fields became first-class in **v0.9.6** and **v0.9.8** respectively:
+
+* [`with_application_type`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.ClientMetadata.html#method.with_application_type) — `"web"` or `"native"`. Desktop and CLI clients register as `"native"`, which is what makes loopback redirect URIs (`http://127.0.0.1:{port}/...`) acceptable to authorization servers.
+* [`with_token_endpoint_auth_signing_alg`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.ClientMetadata.html#method.with_token_endpoint_auth_signing_alg) — the algorithm this one client signs its assertions with, for a `private_key_jwt` registration.
+
+When the registration authenticates with `private_key_jwt`, adopt it with [`from_registration_with_key`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration_with_key), which also refuses a key the registration would not accept — one signing with an algorithm other than the registered `token_endpoint_auth_signing_alg`, or carrying a `kid` an inlined `jwks` cannot resolve:
+
+```rust
+use volga_oauth_client::{ClientError, ClientRegistrationResponse, OAuthClient, PrivateKeyJwt};
+
+fn adopt(
+    registered: &ClientRegistrationResponse,
+    key: PrivateKeyJwt,
+) -> Result<OAuthClient, ClientError> {
+    OAuthClient::from_registration_with_key(registered, key)
+}
+```
+
+::: warning
+Since **v0.9.8**, a client built by [`from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration) refuses a grant its registration did not approve — before reaching the network, rather than as an `unauthorized_client` from the token endpoint. An omitted `grant_types` means `authorization_code` alone (RFC 7591 §2), not carte blanche; only a client that never went through a registration is unconstrained. `refresh_token` is never refused, since RFC 6749 §6 makes it the continuation of a grant already held.
+:::
+
 ::: info
 The RFC 7592 management protocol (reading, updating and deleting a registration) is not implemented, but the `registration_access_token` / `registration_client_uri` pair from the response is surfaced for applications that need it.
 :::
@@ -194,7 +302,38 @@ let config = ClientConfig::new()
 let client = OAuthClient::new("my-client").with_config(config);
 ```
 
-[`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) separates a parsed OAuth error response (`Protocol`, carrying the RFC 6749 §5.2 [`OAuthError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthError.html)) from transport, decode, insecure-URL and validation failures — so you can distinguish "the server said `invalid_grant`" from "the connection dropped".
+[`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) separates a parsed OAuth error response (`Protocol`, carrying the RFC 6749 §5.2 [`OAuthError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthError.html)) from transport, decode, insecure-URL and validation failures — so you can distinguish "the server said `invalid_grant`" from "the connection dropped". Since **v0.9.8** it also carries `Signing`, for a signing configuration that cannot produce the JWS a request needs — a `private_key_jwt` assertion or a DPoP proof.
+
+### Propagating errors from a handler
+
+Since **v0.9.8**, with the `oauth-client` feature enabled on `volga`, a [`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) converts into a [`volga::Error`](https://docs.rs/volga/latest/volga/error/struct.Error.html), so a handler that talks to an authorization server can propagate the failure with `?`:
+
+```rust
+use volga::{HttpResult, ok};
+use volga_oauth_client::{DiscoveryClient};
+
+async fn metadata() -> HttpResult {
+    let metadata = DiscoveryClient::new()
+        .fetch_server_metadata("https://auth.example.com")
+        .await?; // ClientError -> volga::Error
+
+    ok!(metadata.issuer)
+}
+```
+
+The status describes **where** the failure sits rather than echoing what the authorization server answered — this application was the *client* of the call that failed:
+
+| Failure | Status |
+|---|---|
+| the server could not be reached (`Transport`) | `503 Service Unavailable` |
+| it answered unusably — a protocol error, an unexpected status, an unparseable body | `502 Bad Gateway` |
+| this application's own configuration — an insecure URL, metadata that fails validation, a key that cannot sign | `500 Internal Server Error` |
+
+To surface the authorization server's own error code to your caller, match on `ClientError::Protocol` instead of relying on the conversion.
+
+## What's next
+* [Machine-to-Machine Grants](/volga-docs/en/security-access/machine-to-machine.html) — `client_credentials`, JWT bearer and token exchange, for flows with no user involved.
+* [DPoP](/volga-docs/en/security-access/dpop.html) — binding tokens to a key the client holds, so a stolen token is worth nothing.
 
 ## Examples
 * [OAuth Flow](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_flow/src/main.rs) — a full discovery → authorization → code exchange → protected call flow driven by `volga-oauth-client`.

--- a/docs/en/security-access/oauth-client.md
+++ b/docs/en/security-access/oauth-client.md
@@ -36,7 +36,7 @@ At least one of `http1` / `http2` must be enabled.
 
 [`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) resolves the well-known discovery URLs, fetches the documents over HTTPS and validates each against the identifier it was requested for (RFC 8414 §3.3 / RFC 9728 §3.3):
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, DiscoveryClient};
 
 async fn discover() -> Result<(), ClientError> {
@@ -67,7 +67,7 @@ Attach a [`MetadataCache`](https://docs.rs/volga-oauth-client/latest/volga_oauth
 
 [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) drives the OAuth 2.1 Authorization Code flow. PKCE (S256) is generated and applied automatically — it is the protection OAuth 2.1 prescribes for public clients.
 
-```rust
+```rust compile
 use std::sync::Arc;
 use volga_oauth_client::{ClientError, DiscoveryClient, InMemoryTokenStore, OAuthClient};
 
@@ -120,7 +120,7 @@ Always verify the callback `state` with [`matches_state`](https://docs.rs/volga-
 
 Since **v0.9.6**, [`validate_callback`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.validate_callback) checks the whole callback at once — the `state` *and* the RFC 9207 `iss` parameter — and is the recommended replacement for a bare `matches_state`:
 
-```rust
+```rust compile
 use volga_oauth_client::{AuthorizationRequest, AuthorizationServerMetadata, ClientError};
 
 fn check(
@@ -150,7 +150,7 @@ Without a credential the client acts as a **public client** (PKCE is the protect
 
 ### Shared secret
 
-```rust
+```rust compile-fragment
 use volga_oauth_client::{ClientAuthMethod, OAuthClient};
 
 let client = OAuthClient::new("my-client")
@@ -163,7 +163,7 @@ let client = OAuthClient::new("my-client")
 
 Since **v0.9.8** (feature `private-key-jwt`), the client can authenticate with an assertion signed by its own key (RFC 7523 §2.2), so no shared secret ever leaves it:
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, JwsAlgorithm, OAuthClient, PrivateKeyJwt};
 
 fn build() -> Result<OAuthClient, ClientError> {
@@ -184,7 +184,7 @@ Symmetric algorithms are refused: an HMAC secret the server already holds proves
 
 The authorization server verifies assertions with the public half of the key, which it either fetches from a `jwks_uri` or received inline at registration. [`with_public_jwk`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_public_jwk) attaches it and [`jwks()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.jwks) renders the document to publish:
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, JwsAlgorithm, PrivateKeyJwt, PublicJwk};
 
 fn publish(key: PrivateKeyJwt, public: PublicJwk) -> Result<(), ClientError> {
@@ -215,7 +215,7 @@ The registered wire identifiers both sides of the protocol agree on live in one 
 
 Persistence goes through the [`TokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.TokenStore.html) trait. [`InMemoryTokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.InMemoryTokenStore.html) is the built-in process-local implementation — suitable for CLIs, tests and single-instance services; anything durable (a database, an encrypted file, an OS keychain) is one trait impl away.
 
-```rust
+```rust compile
 use volga_oauth_client::{TokenSet, TokenStore};
 
 struct MyStore;
@@ -233,7 +233,7 @@ The key is chosen by the application — typically a user or session identifier,
 
 [`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) submits [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientMetadata.html) to a server's registration endpoint (RFC 7591) and returns the issued credentials. [`OAuthClient::from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration) adopts them into a ready-to-use client:
 
-```rust
+```rust compile
 use volga_oauth_client::{
     ClientError, ClientMetadata, DiscoveryClient, OAuthClient, RegistrationClient,
 };
@@ -267,7 +267,7 @@ Two [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_cli
 
 When the registration authenticates with `private_key_jwt`, adopt it with [`from_registration_with_key`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration_with_key), which also refuses a key the registration would not accept — one signing with an algorithm other than the registered `token_endpoint_auth_signing_alg`, or carrying a `kid` an inlined `jwks` cannot resolve:
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, ClientRegistrationResponse, OAuthClient, PrivateKeyJwt};
 
 fn adopt(
@@ -290,7 +290,7 @@ The RFC 7592 management protocol (reading, updating and deleting a registration)
 
 [`ClientConfig`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientConfig.html) carries the policy shared by every client operation — HTTPS enforcement, per-request timeouts and redirect limits. The defaults are safe for production; the most common override is disabling HTTPS for a local development server:
 
-```rust
+```rust compile-fragment
 use std::time::Duration;
 use volga_oauth_client::{ClientConfig, OAuthClient};
 
@@ -308,7 +308,7 @@ let client = OAuthClient::new("my-client").with_config(config);
 
 Since **v0.9.8**, with the `oauth-client` feature enabled on `volga`, a [`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) converts into a [`volga::Error`](https://docs.rs/volga/latest/volga/error/struct.Error.html), so a handler that talks to an authorization server can propagate the failure with `?`:
 
-```rust
+```rust compile
 use volga::{HttpResult, ok};
 use volga_oauth_client::{DiscoveryClient};
 

--- a/docs/en/security-access/oauth.md
+++ b/docs/en/security-access/oauth.md
@@ -22,7 +22,7 @@ Instead of configuring a static [`DecodingKey`](https://docs.rs/volga/latest/vol
 
 Describe the issuer with [`with_oauth(...)`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth) and activate it explicitly with [`use_oauth()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth):
 
-```rust
+```rust compile
 use serde::Deserialize;
 use volga::{
     App, ok,
@@ -80,7 +80,7 @@ Keys are fetched lazily on the first request and cached, so token validation cos
 
 The issuer is mandatory; everything else has production-safe defaults.
 
-```rust
+```rust compile-fragment
 use std::time::Duration;
 use volga::App;
 
@@ -96,7 +96,7 @@ let app = App::new()
 
 For a local development issuer served over plain HTTP, relax the transport policy:
 
-```rust
+```rust compile-fragment
 let app = App::new()
     .with_oauth(|oauth| oauth
         .with_issuer("http://127.0.0.1:5000")
@@ -123,7 +123,7 @@ A resource server tells clients where to authenticate; an authorization server p
 
 Configure it with [`with_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth_resource_metadata) (or [`set_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.set_oauth_resource_metadata) for the whole value, including the `&str` identifier shorthand) and serve it with [`use_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth_resource_metadata):
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .with_oauth_resource_metadata(|metadata| metadata
         .with_resource("https://api.example.com")
@@ -141,7 +141,7 @@ When bearer authentication is configured, the derived metadata URL is advertised
 
 Applications that are themselves an authorization server publish their endpoints via [`with_oauth_server_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth_server_metadata) and serve the document at one or both discovery paths:
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .with_oauth_server_metadata(|metadata| metadata
         .with_issuer("https://auth.example.com")
@@ -160,7 +160,7 @@ The server-metadata closure is seeded with the OAuth 2.1 prefills `response_type
 
 Two fields worth naming explicitly became typed builders in **v0.9.6** and **v0.9.8**:
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .with_oauth_server_metadata(|metadata| metadata
         .with_issuer("https://auth.example.com")
@@ -175,7 +175,7 @@ Announcing RFC 9207 support makes it **mandatory** for clients: a `volga-oauth-c
 
 Both documents can also come from the `[oauth.resource]` / `[oauth.server]` sections of the configuration file (the `config` feature); the file overrides prior builder calls. The `set_*` shorthand configures a minimal document from the identifier alone:
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .set_oauth_resource_metadata("https://api.example.com")
     .set_oauth_server_metadata("https://auth.example.com");
@@ -188,7 +188,7 @@ app.use_oauth_server_metadata().use_oidc_metadata();
 
 Putting the pieces together, a resource server needs only a handful of lines — token validation is wired straight to the issuer's published keys, with no secret configured anywhere:
 
-```rust
+```rust compile
 use volga::{App, auth::{AuthClaims, roles}, ok};
 use serde::Deserialize;
 

--- a/docs/en/security-access/oauth.md
+++ b/docs/en/security-access/oauth.md
@@ -158,6 +158,21 @@ app.use_oauth_server_metadata()  // GET /.well-known/oauth-authorization-server
 The server-metadata closure is seeded with the OAuth 2.1 prefills `response_types_supported = ["code"]` and `grant_types_supported = ["authorization_code"]`. OIDC-specific fields required by a compliant provider document (`subject_types_supported`, `id_token_signing_alg_values_supported`, `userinfo_endpoint`, …) can be supplied through [`with_additional_field(...)`](https://docs.rs/volga/latest/volga/auth/oauth/struct.AuthorizationServerMetadata.html#method.with_additional_field).
 :::
 
+Two fields worth naming explicitly became typed builders in **v0.9.6** and **v0.9.8**:
+
+```rust
+let mut app = App::new()
+    .with_oauth_server_metadata(|metadata| metadata
+        .with_issuer("https://auth.example.com")
+        // RFC 9207: the `iss` parameter is returned in authorization responses,
+        // which lets clients detect an authorization server mix-up
+        .with_authorization_response_iss_parameter(true)
+        // RFC 9449: the algorithms accepted in DPoP proofs
+        .with_dpop_signing_algs(["ES256"]));
+```
+
+Announcing RFC 9207 support makes it **mandatory** for clients: a `volga-oauth-client` [callback validation](/volga-docs/en/security-access/oauth-client.html#validating-the-callback) then rejects a response that carries no `iss`. `with_authorization_response_iss_parameter` is also accepted in the `[oauth.server]` config file section. See [DPoP](/volga-docs/en/security-access/dpop.html) for the client half of the second one; the resource-side `dpop_signing_alg_values_supported` is available on [`ProtectedResourceMetadata`](https://docs.rs/volga/latest/volga/auth/oauth/struct.ProtectedResourceMetadata.html) under the same name.
+
 Both documents can also come from the `[oauth.resource]` / `[oauth.server]` sections of the configuration file (the `config` feature); the file overrides prior builder calls. The `set_*` shorthand configures a minimal document from the identifier alone:
 
 ```rust

--- a/docs/ru/advanced-patterns/custom-trace-opt-head.md
+++ b/docs/ru/advanced-patterns/custom-trace-opt-head.md
@@ -36,7 +36,7 @@ async fn main() -> std::io::Result<()> {
 ## Метод OPTIONS
 
 Для специальной обработки запросов `OPTIONS` используйте метод [`map_options`](https://docs.rs/volga/latest/volga/app/router/trait.Router.html#tymethod.map_options) для сопоставления этого метода HTTP:
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]

--- a/docs/ru/getting-started/query-params.md
+++ b/docs/ru/getting-started/query-params.md
@@ -7,7 +7,7 @@
 
 В качестве примера, как получить доступ к параметрам запроса, можно рассмотреть следующий код:
 
-```rust
+```rust compile
 use volga::{App, Query, ok};
 use serde::Deserialize;
 
@@ -48,7 +48,7 @@ Hello World!
 
 Для API, которые требуют нескольких параметров запроса, настройка выполняется аналогично:
 
-```rust
+```rust compile
 use volga::{App, Query, ok};
 use serde::Deserialize;
 

--- a/docs/ru/getting-started/quick-start.md
+++ b/docs/ru/getting-started/quick-start.md
@@ -61,6 +61,22 @@ let mut app = App::new();
 // Привязка сервера к http://localhost:5000
 let mut app = App::new().bind("localhost:5000");
 ```
+Начиная с **v0.9.7**, метод [`bind()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.bind) принимает полную грамматику адресов [`tokio::net::TcpListener::bind`](https://docs.rs/tokio/latest/tokio/net/struct.TcpListener.html#method.bind):
+```rust
+let app = App::new().bind("127.0.0.1:7878");      // литерал IPv4
+let app = App::new().bind("[::1]:7878");          // литерал IPv6
+let app = App::new().bind("::1:7878");            // литерал IPv6 без скобок
+let app = App::new().bind("[fe80::1%eth0]:7878"); // литерал IPv6 с зоной
+let app = App::new().bind("localhost:7878");      // имя хоста
+let app = App::new().bind(([127, 0, 0, 1], 7878)); // всё, что преобразуется в SocketAddr
+```
+Имена хостов резолвятся при старте сервера — асинхронно, без блокировки рантайма. Если имя резолвится в несколько адресов, они перебираются в порядке резолва, и побеждает первый, к которому удалось привязаться.
+
+:::warning
+До **v0.9.7** адрес, который не разбирался как `SocketAddr`, на не-Windows платформах молча заменялся на `0.0.0.0:7878`. Под это попадали в том числе `localhost:3000` и `::1:3000` — то есть сервер, который должен был остаться на loopback, слушал **все** интерфейсы, без ошибки и без записи в лог.
+
+Теперь непригодный адрес сообщается явно: [`run()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.run) возвращает `io::Error`, а [`run_blocking()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.run_blocking) логирует ошибку и не запускает сервер. Если вы полагаетесь на привязку к loopback как на меру безопасности — обновитесь.
+:::
 
 Далее, обработчик запроса `GET /hello` привязывается к маршруту:
 

--- a/docs/ru/getting-started/quick-start.md
+++ b/docs/ru/getting-started/quick-start.md
@@ -29,7 +29,7 @@ tokio = { version = "...", features = ["full"] }
 
 Создайте стартовую точку приложения в файле `main.rs`:
 
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]
@@ -51,18 +51,18 @@ async fn main() -> std::io::Result<()> {
 
 Структура [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html) представляет ваше API и по умолчанию привязывается к адресу `http://localhost:7878`:
 
-```rust
+```rust compile-fragment
 let mut app = App::new();
 ```
 
 Если требуется привязать сервер к другому сокету, можно использовать метод [`bind()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.bind), например:
 
-```rust
+```rust compile-fragment
 // Привязка сервера к http://localhost:5000
 let mut app = App::new().bind("localhost:5000");
 ```
 Начиная с **v0.9.7**, метод [`bind()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.bind) принимает полную грамматику адресов [`tokio::net::TcpListener::bind`](https://docs.rs/tokio/latest/tokio/net/struct.TcpListener.html#method.bind):
-```rust
+```rust compile-fragment
 let app = App::new().bind("127.0.0.1:7878");      // литерал IPv4
 let app = App::new().bind("[::1]:7878");          // литерал IPv6
 let app = App::new().bind("::1:7878");            // литерал IPv6 без скобок
@@ -136,7 +136,7 @@ volga = { version = "..." }
 
 Тогда `main.rs` может выглядеть так:
 
-```rust
+```rust compile
 use volga::{App, ok};
 
 fn main() {

--- a/docs/ru/getting-started/route-groups.md
+++ b/docs/ru/getting-started/route-groups.md
@@ -8,7 +8,7 @@
 
 Пример, демонстрирующий использование групп маршрутов в приложении:
 
-```rust
+```rust compile
 use volga::{App, HttpResult, ok};
 
 #[tokio::main]

--- a/docs/ru/getting-started/route-params.md
+++ b/docs/ru/getting-started/route-params.md
@@ -6,7 +6,7 @@
 
 Вот как настроить простой динамический маршрут, который приветствует пользователя по имени:
 
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]
@@ -42,7 +42,7 @@ Hello sun!
 
 Вы также можете настроить маршруты с несколькими параметрами. Например:
 
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]
@@ -73,7 +73,7 @@ Hello beautiful world!
 
 Кроме того, вы можете использовать [`NamedPath<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/path/struct.NamedPath.html), чтобы обернуть параметры маршрута в специализированную структуру. Где `T` — это либо десериализуемая структура, либо `HashMap`. Убедитесь, что у вас установлена библиотека [serde](https://crates.io/crates/serde):
 
-```rust
+```rust compile
 use volga::{App, NamedPath, ok};
 use serde::Deserialize;
 

--- a/docs/ru/middleware-infrastructure/compression.md
+++ b/docs/ru/middleware-infrastructure/compression.md
@@ -20,7 +20,7 @@ volga = { version = "...", features = ["compression-brotli", "compression-gzip"]
 ## Пример использования
 
 Чтобы использовать сжатие в вашем приложении, используйте метод [`use_compression()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_compression) в вашем `main.rs`:
-```rust
+```rust compile
 use volga::{App, ok};
 use serde::Serialize;
  

--- a/docs/ru/middleware-infrastructure/config-files.md
+++ b/docs/ru/middleware-infrastructure/config-files.md
@@ -37,7 +37,7 @@ msg = "World"
 
 Определите структуру для вашей секции и привяжите её при настройке приложения:
 
-```rust
+```rust compile
 use volga::{App, Config, ok};
 use serde::Deserialize;
 
@@ -71,7 +71,7 @@ async fn main() -> std::io::Result<()> {
 
 Самый простой вариант — [`with_default_config()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_default_config) автоматически ищет `app_config.toml` или `app_config.json` в текущей рабочей директории:
 
-```rust
+```rust compile-fragment
 let app = App::new().with_default_config();
 ```
 
@@ -160,7 +160,7 @@ let app = App::new().with_config(|cfg| {
 
 Используйте экстрактор [`Config<T>`](https://docs.rs/volga/latest/volga/config/struct.Config.html) для доступа к привязанной секции в любом обработчике запросов. Он выполняет одну атомарную загрузку + `Arc::clone` на каждый запрос — без десериализации во время выполнения:
 
-```rust
+```rust compile
 use volga::{App, Config, ok};
 use serde::Deserialize;
 

--- a/docs/ru/middleware-infrastructure/cors.md
+++ b/docs/ru/middleware-infrastructure/cors.md
@@ -13,7 +13,7 @@ volga = { version = "...", features = ["middleware"] }
 
 Следующий пример демонстрирует максимально разрешительную конфигурацию CORS:  
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() -> std::io::Result<()> {
 
 Если требуется более строгая конфигурация, можно указать конкретные разрешённые источники, заголовки и методы:  
 
-```rust
+```rust compile
 use volga::{App, http::Method};
 
 #[tokio::main]
@@ -76,7 +76,7 @@ async fn main() -> std::io::Result<()> {
 
 Если вы настроите только именованную политику, маршруты **не** получат CORS, если вы явно не прикрепите эту политику с помощью [`cors_with(...)`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.cors_with).
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -110,7 +110,7 @@ async fn main() -> std::io::Result<()> {
 
 Вы можете прикрепить политику к одному маршруту:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]

--- a/docs/ru/middleware-infrastructure/decompression.md
+++ b/docs/ru/middleware-infrastructure/decompression.md
@@ -38,7 +38,7 @@ async fn main() -> std::io::Result<()> {
     app.run().await
 }
 ```
-Затем вы можете проверить это с помощью команды `curl`, предварительно создав и упаковав файл `users.json.gz`, который вы можете сделать из ответа [примера](/volga-docs/ru/getting-started/compression.html#пример-использования) предыдущей темы: Сжатие ответов:
+Затем вы можете проверить это с помощью команды `curl`, предварительно создав и упаковав файл `users.json.gz`, который вы можете сделать из ответа [примера](/volga-docs/ru/middleware-infrastructure/compression.html#пример-использования) предыдущей темы: Сжатие ответов:
 ```bash
 curl -v -X POST --location 'http://127.0.0.1:7878/users' \
     -H "Content-Type: application/json" \

--- a/docs/ru/middleware-infrastructure/decompression.md
+++ b/docs/ru/middleware-infrastructure/decompression.md
@@ -21,7 +21,7 @@ volga = { version = "...", features = ["decompression-brotli", "decompression-gz
 
 Чтобы использовать распаковку в вашем приложении, используйте метод [`use_decompression()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_decompression) в вашем `main.rs`:
 
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]

--- a/docs/ru/middleware-infrastructure/middleware.md
+++ b/docs/ru/middleware-infrastructure/middleware.md
@@ -15,7 +15,7 @@ volga = { version = "...", features = ["middleware"] }
 
 Метод [`filter()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.filter) позволяет задать условную логику (например, проверку прав или валидацию) для конкретного маршрута или группы маршрутов.
 
-```rust
+```rust compile
 use volga::{App, Path};
 
 #[tokio::main]
@@ -44,7 +44,7 @@ async fn sum(x: i32, y: i32) -> i32 {
 
 Метод [`tap_req()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.tap_req) позволяет получить доступ к [`HttpRequestMut`](https://docs.rs/volga/latest/volga/http/request/struct.HttpRequestMut.html), чтобы модифицировать или исследовать запрос до обработки.
 
-```rust
+```rust compile
 use volga::{App, HttpRequestMut, headers};
 
 headers! {
@@ -70,7 +70,7 @@ async fn main() -> std::io::Result<()> {
 
 Метод [`map_ok()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_ok) позволяет изменить или дополнить HTTP-ответ после успешной обработки.
 
-```rust
+```rust compile
 use volga::{App, HttpResponse, HttpResult, headers};
 
 headers! {

--- a/docs/ru/middleware-infrastructure/middleware.md
+++ b/docs/ru/middleware-infrastructure/middleware.md
@@ -135,7 +135,7 @@ async fn produce_err() -> IoError {
 ```
 
 ::: tip
-Если вызвать [`map_err()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_err) у [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html), вы настроите глобальный обработчик ошибок. Подробнее о глобальной обработке ошибок читайте [здесь](/volga-docs/ru/reliability-observability/errors).
+Если вызвать [`map_err()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_err) у [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html), вы настроите глобальный обработчик ошибок. Подробнее о глобальной обработке ошибок читайте [здесь](/volga-docs/ru/reliability-observability/errors.html).
 :::
 
 ## Примеры

--- a/docs/ru/middleware-infrastructure/middlewares.md
+++ b/docs/ru/middleware-infrastructure/middlewares.md
@@ -18,7 +18,7 @@ volga = { version = "...", features = ["middleware"] }
 ### Пример: Последовательное выполнение Middleware
 
 Практический пример настройки последовательного выполнения middleware в Volga:
-```rust
+```rust compile
 use volga::{App, ok};
 
 #[tokio::main]

--- a/docs/ru/middleware-infrastructure/parameterized-middleware.md
+++ b/docs/ru/middleware-infrastructure/parameterized-middleware.md
@@ -28,7 +28,7 @@ pub trait Middleware: Send + Sync + 'static {
 ## Пример: Middleware `Timeout`
 
 Ниже приведён небольшой middleware, добавляющий искусственную задержку перед дальнейшей обработкой запроса. Длительность задержки настраивается при регистрации:
-```rust
+```rust compile
 use std::time::Duration;
 use volga::{App, HttpResult, middleware::{HttpContext, NextFn, Middleware}};
 
@@ -75,7 +75,7 @@ impl Middleware for Timeout {
 :::
 
 `attach()` также принимает замыкания, но в этом случае требуется указывать аннотации типов для аргументов:
-```rust
+```rust compile
 use volga::{App, middleware::{HttpContext, NextFn}};
 
 #[tokio::main]
@@ -93,7 +93,7 @@ async fn main() -> std::io::Result<()> {
 ## Регистрация на маршрутах и группах маршрутов
 
 Параметризованные middleware могут быть прикреплены не только ко всему приложению, но и к отдельным маршрутам и [группам маршрутов](../getting-started/route-groups.md):
-```rust
+```rust compile
 use std::time::Duration;
 use volga::{App, HttpResult, middleware::{HttpContext, NextFn, Middleware}};
 
@@ -147,7 +147,7 @@ impl Middleware for Timeout {
 
 Тот же параметризованный подход работает и для остальных middleware-трейтов. Помимо [`Middleware`](https://docs.rs/volga/latest/volga/middleware/handler/trait.Middleware.html), вы можете реализовать [`Filter`](https://docs.rs/volga/latest/volga/middleware/handler/trait.Filter.html), [`TapReq`](https://docs.rs/volga/latest/volga/middleware/handler/trait.TapReq.html), [`MapOk`](https://docs.rs/volga/latest/volga/middleware/handler/trait.MapOk.html), [`MapErr`](https://docs.rs/volga/latest/volga/http/endpoints/handlers/trait.MapErr.html) и [`With`](https://docs.rs/volga/latest/volga/middleware/handler/trait.With.html) на собственных типах. Они регистрируются теми же методами, что и их аналоги-замыкания — [`filter()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.filter), [`tap_req()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.tap_req), [`map_ok()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_ok), [`map_err()`](https://docs.rs/volga/latest/volga/app/router/struct.Route.html#method.map_err) и [`with()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with) соответственно. Например, переиспользуемый параметризованный фильтр:
 
-```rust
+```rust compile
 use volga::{App, headers::HttpHeaders, middleware::Filter};
 
 #[tokio::main]

--- a/docs/ru/middleware-infrastructure/rate-limiting.md
+++ b/docs/ru/middleware-infrastructure/rate-limiting.md
@@ -59,7 +59,7 @@ Middleware для rate limiting можно подключить на трёх у
 
 Token bucket начинается заполненным (до `capacity` токенов) и пополняется с постоянной скоростью. Каждый запрос потребляет один токен. Когда корзина пуста, запросы отклоняются до тех пор, пока токены не пополнятся.
 
-```rust
+```rust compile-fragment
 use volga::rate_limiting::TokenBucket;
 
 let bucket = TokenBucket::new(10, 5.0);
@@ -110,7 +110,7 @@ let mut app = App::new()
 
 Применение rate limiting ко всем входящим запросам:
 
-```rust
+```rust compile-fragment
 use volga::rate_limiting::by;
 
 app.use_token_bucket(by::ip());
@@ -205,7 +205,7 @@ app.use_fixed_window(by::ip());
 
 Store trait'ы определены в крейте `volga_rate_limiter`, и каждый требует реализации одной атомарной операции:
 
-```rust
+```rust compile
 use volga::rate_limiting::TokenBucketStore;
 use volga::rate_limiting::TokenBucketParams;
 

--- a/docs/ru/middleware-infrastructure/static-files.md
+++ b/docs/ru/middleware-infrastructure/static-files.md
@@ -32,7 +32,7 @@ project/
 
 После создания файлов HTML, CSS и JS можно настроить минимальный сервер в `main.rs`:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -59,7 +59,7 @@ async fn main() -> std::io::Result<()> {
 
 Чтобы раздавать специальный файл (например, `404.html`) при неизвестных маршрутах, используйте [`map_fallback_to_file()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_fallback_to_file), внутри он использует другой метод - [`map_fallback()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_fallback) который, в свою очередь, настраивает специальный обработчик, вызываемый при обнаружении неизвестного маршрута:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -83,7 +83,7 @@ async fn main() -> std::io::Result<()> {
 
 Для упрощения можно использовать [`use_static_files()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_static_files), который объединяет [`map_static_assets()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_static_assets) и [`map_fallback_to_file()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_fallback_to_file), Однако, последний метод будет задействован, только если указан специальный резервный файл:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -109,7 +109,7 @@ async fn main() -> std::io::Result<()> {
 
 По умолчанию просмотр каталогов отключен. Его можно включить с помощью [`with_files_listing()`](https://docs.rs/volga/latest/volga/app/env/struct.HostEnv.html#method.with_files_listing), однако это не рекомендуется для продакшн-сред.
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -135,7 +135,7 @@ async fn main() -> std::io::Result<()> {
 
 Вот как можно добиться той же конфигурации с помощью `HostEnv`:
 
-```rust
+```rust compile
 use volga::{App, File, app::HostEnv};
 
 #[tokio::main]

--- a/docs/ru/protocols-realtime/http.md
+++ b/docs/ru/protocols-realtime/http.md
@@ -17,7 +17,7 @@ volga = { version = "...", features = ["full"] }
 ## HTTP-методы
 Для каждого стандартного глагола в Волге есть именованный метод `map_*` — он регистрируется на [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html) или на [`RouteGroup`](https://docs.rs/volga/latest/volga/routing/struct.RouteGroup.html):
 
-```rust
+```rust compile-fragment
 app.map_get("/items", || async { ok!("list") });
 app.map_post("/items", || async { ok!("created") });
 app.map_put("/items/{id}", || async { ok!("updated") });
@@ -37,7 +37,7 @@ app.map_trace("/items", || async { ok!() });
 
 Обработчик регистрируется через [`map_query()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_query):
 
-```rust
+```rust compile
 use volga::{App, Json, ok};
 use serde::Deserialize;
 
@@ -75,7 +75,7 @@ async fn main() -> std::io::Result<()> {
 ### Произвольный метод
 Также с **v0.9.4** метод [`map()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map) регистрирует маршрут для любого HTTP-метода. Это удобно, когда глагол известен только во время выполнения, когда один обработчик обслуживает несколько методов, или для нестандартных глаголов:
 
-```rust
+```rust compile
 use volga::{App, ok};
 use volga::http::Method;
 

--- a/docs/ru/protocols-realtime/http.md
+++ b/docs/ru/protocols-realtime/http.md
@@ -1,4 +1,6 @@
-# HTTP/1 и HTTP/2
+# Версии и методы HTTP
+
+## HTTP/1 и HTTP/2
 Начиная с **v0.3.1**, можно настроить версию HTTP.
 Если добавить Волгу вот так, по умолчанию используется HTTP/1:
 ```toml
@@ -11,3 +13,91 @@ volga = { version = "..." }
 volga = { version = "...", features = ["full"] }
 ```
 При использовании `full` HTTP/2 применяется, если это возможно, иначе автоматически используется HTTP/1.
+
+## HTTP-методы
+Для каждого стандартного глагола в Волге есть именованный метод `map_*` — он регистрируется на [`App`](https://docs.rs/volga/latest/volga/app/struct.App.html) или на [`RouteGroup`](https://docs.rs/volga/latest/volga/routing/struct.RouteGroup.html):
+
+```rust
+app.map_get("/items", || async { ok!("list") });
+app.map_post("/items", || async { ok!("created") });
+app.map_put("/items/{id}", || async { ok!("updated") });
+app.map_patch("/items/{id}", || async { ok!("patched") });
+app.map_delete("/items/{id}", || async { ok!("deleted") });
+app.map_head("/items", || async { ok!() });
+app.map_options("/items", || async { ok!() });
+app.map_trace("/items", || async { ok!() });
+```
+
+::: tip
+`HEAD` подключается неявно для каждого маршрута `GET`, поэтому [`map_head`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_head) нужен только для собственной реализации. См. [Свои обработчики HEAD, OPTIONS и TRACE](/volga-docs/ru/advanced-patterns/custom-trace-opt-head.html).
+:::
+
+### Метод `QUERY`
+Начиная с **v0.9.4**, Волга поддерживает HTTP-метод `QUERY` — безопасный идемпотентный глагол с телом запроса, для поисковых запросов, которые слишком велики или слишком структурированы для строки запроса URI.
+
+Обработчик регистрируется через [`map_query()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_query):
+
+```rust
+use volga::{App, Json, ok};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct SearchQuery {
+    criteria: String
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_query("/search", |query: Json<SearchQuery>| async move {
+        // выполняем поиск по query.criteria...
+        ok!("search results...")
+    });
+
+    app.run().await
+}
+```
+
+Проверить можно через `curl`:
+```bash
+> curl -X QUERY "http://localhost:7878/search" -H "Content-Type: application/json" -d '{"criteria":"volga"}'
+```
+
+::: warning
+Не путайте [`map_query()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_query) с экстрактором [`Query<T>`](/volga-docs/ru/getting-started/query-params.html): первый регистрирует маршрут для **глагола** `QUERY`, второй читает **строку запроса** URI любого запроса.
+:::
+
+::: tip
+Сложные критерии выборки лучше передавать в теле запроса `QUERY`. Параметры строки запроса стоит оставить для метаданных, влияющих на маршрутизацию и кеширование: тенант, локаль, версия, флаги, совместимость пагинации.
+:::
+
+### Произвольный метод
+Также с **v0.9.4** метод [`map()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map) регистрирует маршрут для любого HTTP-метода. Это удобно, когда глагол известен только во время выполнения, когда один обработчик обслуживает несколько методов, или для нестандартных глаголов:
+
+```rust
+use volga::{App, ok};
+use volga::http::Method;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map(Method::GET, "/hello", || async {
+        ok!("Hello, World!")
+    });
+
+    // строковый глагол и шаблон, собранный во время выполнения, тоже работают
+    app.map("QUERY", format!("/search/{}", "v1"), || async {
+        ok!("search results...")
+    });
+
+    app.run().await
+}
+```
+
+Аргумент `method` принимает всё, что преобразуется в [`Method`](https://docs.rs/http/latest/http/method/struct.Method.html), включая строковые глаголы, а шаблон — как заимствованный `&str` (без аллокации), так и владеющий `String`, собранный во время выполнения.
+
+::: warning
+[`map()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map) **паникует**, если метод не преобразуется в корректный [`Method`](https://docs.rs/http/latest/http/method/struct.Method.html). Маршруты регистрируются на старте, поэтому некорректный глагол — это ошибка программиста, а не состояние времени выполнения.
+:::

--- a/docs/ru/protocols-realtime/https.md
+++ b/docs/ru/protocols-realtime/https.md
@@ -78,7 +78,7 @@ openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 36
 
 ### Код для использования сертификата и закрытого ключа
 Если вы сгенерировали сертификат и закрытый ключ в папке, где находится ваш `Cargo.toml`, вы можете просто сделать следующее:
-```rust
+```rust compile
 use volga::{App, tls::TlsConfig};
 
 #[tokio::main]

--- a/docs/ru/protocols-realtime/sse.md
+++ b/docs/ru/protocols-realtime/sse.md
@@ -6,7 +6,7 @@
 
 В примере ниже показано, как создать простую конечную точку SSE. Она сопоставляет запрос `GET` с маршрутом `/events`, устанавливает Content Type как `text/event-stream` и непрерывно отправляет сообщение `"Hello, world!"` раз в секунду, пока клиент не отключится:
 
-```rust
+```rust compile
 use volga::{App, http::sse::Message, sse_stream};
 use std::time::Duration;
 
@@ -35,7 +35,7 @@ async fn main() -> std::io::Result<()> {
 
 Для простых текстовых сообщений используйте метод [`data()`](https://docs.rs/volga/latest/volga/http/endpoints/args/sse/struct.Message.html#method.data), как показано выше. Если вам необходимо отправить структурированные данные, такие как JSON, используйте метод [`json()`](https://docs.rs/volga/latest/volga/http/endpoints/args/sse/struct.Message.html#method.json), который принимает любой тип, реализующий типаж [`serde::Serialize`](https://docs.rs/serde/1.0.219/serde/ser/trait.Serialize.html):
 
-```rust
+```rust compile-fragment
 use volga::http::sse::Message;
 use serde::Serialize;
 

--- a/docs/ru/protocols-realtime/ws.md
+++ b/docs/ru/protocols-realtime/ws.md
@@ -22,7 +22,7 @@ volga = { version = "...", features = ["http2", "ws"] }
 
 После обновления `Cargo.toml` с флагом `ws` вы можете реализовать базовый обработчик сообщений с помощью метода [`map_msg()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_msg). Следующий пример отвечает отформатированной строкой, содержащей полученное сообщение:
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -40,7 +40,7 @@ async fn main() -> std::io::Result<()> {
 
 Это очень простой пример. Чтобы получить больше контроля над конкретным соединением, вы можете воспользоваться другим методом - [`map_ws()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_ws).
 
-```rust
+```rust compile
 use volga::{App, ws::WebSocket};
 
 #[tokio::main]
@@ -100,7 +100,7 @@ async fn main() -> std::io::Result<()> {
 
 Для полного контроля, например, для настройки подключения или указания некоторых подпротоколов есть еще один метод - [`map_conn()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_conn), вы можете использовать его следующим образом:
 
-```rust
+```rust compile-fragment
 use volga::{App, ws::{WebSocketConnection, WebSocket}};
 
 #[tokio::main]

--- a/docs/ru/reliability-observability/cancellation.md
+++ b/docs/ru/reliability-observability/cancellation.md
@@ -4,7 +4,7 @@
 
 Вот как это можно использовать:
 
-```rust
+```rust compile
 use std::time::Duration;
 use volga::{App, CancellationToken, ok};
 
@@ -30,7 +30,7 @@ async fn main() -> std::io::Result<()> {
 }
 ```
 Более продвинутый вариант с использованием [`tokio::select!`](https://docs.rs/tokio/latest/tokio/macro.select.html):
-```rust
+```rust compile
 use std::time::Duration;
 use volga::{App, CancellationToken, ok};
 

--- a/docs/ru/reliability-observability/errors.md
+++ b/docs/ru/reliability-observability/errors.md
@@ -5,7 +5,7 @@
 Функция принимает объект типа [`Error`](https://docs.rs/volga/latest/volga/error/struct.Error.html) и должна вернуть ответ, реализующий типаж [`IntoResponse`](https://docs.rs/volga/latest/volga/http/response/into_response/trait.IntoResponse.html).
 
 ### Пример:
-```rust
+```rust compile
 use volga::{App, error::Error, status};
 
 #[tokio::main]
@@ -42,7 +42,7 @@ status!(error.status.as_u16(), "{:?}", error)
 volga = { version = "...", features = ["problem-details"] }
 ```
 Затем вы можете вернуть структуру [`Problem`](https://docs.rs/volga/latest/volga/error/problem/struct.Problem.html) из обработчика запроса:
-```rust
+```rust compile
 use volga::{App, error::Problem};
 use serde::Serialize;
 
@@ -99,7 +99,7 @@ Content-Type: application/problem+json
 ## Центральная обработка ошибок с Problem Details
 
 Кроме того, вы можете комбинировать [`Problem`](https://docs.rs/volga/latest/volga/error/problem/struct.Problem.html) с [`map_err`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.map_err), используя метод [`use_problem_details()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_problem_details):
-```rust
+```rust compile
 use volga::{App, error::Error};
 
 #[tokio::main]

--- a/docs/ru/reliability-observability/graceful-shutdown.md
+++ b/docs/ru/reliability-observability/graceful-shutdown.md
@@ -8,7 +8,7 @@
 
 [`App::with_shutdown()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_shutdown) возвращает приложение вместе со свежим хэндлом:
 
-```rust
+```rust compile
 use std::time::Duration;
 use volga::App;
 
@@ -31,7 +31,7 @@ async fn main() -> std::io::Result<()> {
 
 Если хэндл принадлежит другому коду — создан при старте, хранится в состоянии приложения, разделяется с фоновыми задачами — зарегистрируйте его на уже созданном приложении через [`with_shutdown_signal()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_shutdown_signal):
 
-```rust
+```rust compile
 use volga::{App, ShutdownHandle};
 
 #[tokio::main]
@@ -55,7 +55,7 @@ async fn main() -> std::io::Result<()> {
 
 [`shutdown_on()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.shutdown_on) инициирует плавное завершение, когда переданный future завершается. Это удобно для всего, что уже сигнализирует о себе асинхронно: канал `oneshot`, внешний вотчдог, уведомление о перезагрузке конфигурации, неудавшееся продление аренды.
 
-```rust
+```rust compile
 use volga::App;
 
 #[tokio::main]
@@ -81,7 +81,7 @@ Future запускается в рантайме Tokio в момент стар
 
 Поскольку хэндл — это обычное клонируемое значение, его можно передать через [внедрение зависимостей](/volga-docs/ru/advanced-patterns/di.html) и получить административный эндпоинт остановки:
 
-```rust
+```rust compile
 use volga::{App, ShutdownHandle, di::Dc, ok};
 
 #[tokio::main]

--- a/docs/ru/reliability-observability/graceful-shutdown.md
+++ b/docs/ru/reliability-observability/graceful-shutdown.md
@@ -1,0 +1,111 @@
+# Плавное завершение работы
+
+Волга всегда завершается плавно по сигналу ОС — `Ctrl+C` и `SIGTERM` на Unix и их аналоги на Windows. Когда приходит сигнал, слушатель перестаёт принимать новые соединения, уже начатым запросам даётся возможность завершиться, и только после этого [`run()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.run) возвращает управление.
+
+Начиная с **v0.9.3**, то же самое завершение можно инициировать из своего кода с помощью [`ShutdownHandle`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html) — для административного эндпоинта, вотчдога, истёкшей аренды или воркера, доделавшего задачу, ради которой процесс и запускался.
+
+## Приложение с хэндлом
+
+[`App::with_shutdown()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_shutdown) возвращает приложение вместе со свежим хэндлом:
+
+```rust
+use std::time::Duration;
+use volga::App;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let (app, shutdown) = App::with_shutdown();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        shutdown.shutdown();
+    });
+
+    app.run().await
+}
+```
+
+Хэндл дёшево клонируется и может быть передан куда угодно; вызов [`shutdown()`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html#method.shutdown) у любого клона запускает одно и то же плавное завершение. Он **дополняет** встроенный обработчик сигналов, а не заменяет его — срабатывает то, что произошло раньше.
+
+## Регистрация внешнего хэндла
+
+Если хэндл принадлежит другому коду — создан при старте, хранится в состоянии приложения, разделяется с фоновыми задачами — зарегистрируйте его на уже созданном приложении через [`with_shutdown_signal()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_shutdown_signal):
+
+```rust
+use volga::{App, ShutdownHandle};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let handle = ShutdownHandle::new();
+    let app = App::new().with_shutdown_signal(handle.clone());
+
+    // теперь `handle` может жить в состоянии, в супервизоре, в CLI-команде...
+    app.run().await
+}
+```
+
+[`ShutdownHandle`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html) построен поверх [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html) из Tokio, поэтому он может принять уже существующий токен через [`ShutdownHandle::from_token()`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html#method.from_token) (или эквивалентный `From<CancellationToken>`) — так сервер встраивается в дерево отмены, которое уже используется в остальном процессе.
+
+Ещё два метода позволяют наблюдать за состоянием, а не инициировать его:
+
+* [`is_shutdown_requested()`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html#method.is_shutdown_requested) — было ли запрошено завершение;
+* [`cancelled()`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html#method.cancelled) — future, который завершается в этот момент, чтобы фоновые задачи сворачивались вместе с сервером.
+
+## Завершение по future
+
+[`shutdown_on()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.shutdown_on) инициирует плавное завершение, когда переданный future завершается. Это удобно для всего, что уже сигнализирует о себе асинхронно: канал `oneshot`, внешний вотчдог, уведомление о перезагрузке конфигурации, неудавшееся продление аренды.
+
+```rust
+use volga::App;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+    let app = App::new()
+        .bind("127.0.0.1:7878")
+        .shutdown_on(async move { let _ = rx.await; });
+
+    // отправка в `tx` позже инициирует плавное завершение
+    app.run().await
+}
+```
+
+Несколько вызовов [`shutdown_on()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.shutdown_on) складываются: завершение любого из зарегистрированных future запускает остановку, и все они сочетаются с обработчиком сигналов ОС и с ранее зарегистрированным [`ShutdownHandle`](https://docs.rs/volga/latest/volga/app/shutdown/struct.ShutdownHandle.html). Если хэндл не регистрировался, он создаётся внутри автоматически.
+
+::: tip
+Future запускается в рантайме Tokio в момент старта приложения, поэтому [`shutdown_on()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.shutdown_on) безопасно вызывать до того, как рантайм вообще существует — в том числе перед [`run_blocking()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.run_blocking).
+:::
+
+## Завершение из обработчика
+
+Поскольку хэндл — это обычное клонируемое значение, его можно передать через [внедрение зависимостей](/volga-docs/ru/advanced-patterns/di.html) и получить административный эндпоинт остановки:
+
+```rust
+use volga::{App, ShutdownHandle, di::Dc, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let handle = ShutdownHandle::new();
+
+    let mut app = App::new().with_shutdown_signal(handle.clone());
+    app.add_singleton(handle);
+
+    app.map_post("/admin/shutdown", |handle: Dc<ShutdownHandle>| async move {
+        handle.shutdown();
+        ok!("shutting down")
+    });
+
+    app.run().await
+}
+```
+
+Ответ при этом всё равно будет доставлен: запрос, инициировавший остановку, находится в обработке, а именно таких запросов и дожидается плавное завершение.
+
+::: warning
+Такой эндпоинт обязательно закрывайте [аутентификацией и авторизацией](/volga-docs/ru/security-access/auth.html) — он останавливает сервер для всех.
+:::
+
+## Завершение и отмена запроса
+
+Вещи связанные, но разные. Завершение работы даёт активным запросам **доработать**; [отмена запроса](/volga-docs/ru/reliability-observability/cancellation.html) срабатывает, когда *клиент* пропал посреди запроса. Долгоиграющий обработчик стоит писать с учётом обоих: следить за [`CancellationToken`](https://docs.rs/volga/latest/volga/app/endpoints/args/cancellation_token/type.CancellationToken.html) конкретного запроса, чтобы не работать на ушедшего клиента, и за хэндлом завершения, чтобы не удерживать процесс дольше, чем нужно.

--- a/docs/ru/reliability-observability/tracing.md
+++ b/docs/ru/reliability-observability/tracing.md
@@ -13,7 +13,7 @@ tracing-subscriber = "0.3"
 ```
 
 ## Базовая конфигурация
-```rust
+```rust compile
 use volga::{App, tracing::TracingConfig};
 use tracing::trace;
 use tracing_subscriber::prelude::*;

--- a/docs/ru/requests-responses/body.md
+++ b/docs/ru/requests-responses/body.md
@@ -13,7 +13,7 @@ tokio = { version = "...", features = ["full"] }
 http-body-util = "0.1"
 ```
 
-```rust
+```rust compile
 use http_body_util::BodyExt;
 use volga::{App, HttpBody, ok};
 
@@ -44,7 +44,7 @@ async fn main() -> std::io::Result<()> {
 
 [`HttpBody`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html) можно и возвращать, поэтому обработчик-транзит сводится к перемещению тела в ответ — ничего не буферизуется:
 
-```rust
+```rust compile
 use volga::{App, HttpBody, HttpResponse, headers::ContentType};
 
 #[tokio::main]
@@ -73,7 +73,7 @@ tokio = { version = "...", features = ["full"] }
 futures-util = "0.3"
 ```
 
-```rust
+```rust compile
 use futures_util::StreamExt;
 use volga::{App, http::HttpBodyStream, ok};
 

--- a/docs/ru/requests-responses/body.md
+++ b/docs/ru/requests-responses/body.md
@@ -1,0 +1,112 @@
+# Сырое тело запроса
+
+Большинство обработчиков используют типизированные экстракторы — [`Json<T>`](/volga-docs/ru/requests-responses/json-payload.html), [`Form<T>`](/volga-docs/ru/requests-responses/form.html), [`Multipart`](/volga-docs/ru/requests-responses/multipart.html) — и никогда не работают с байтами напрямую. Но когда байты всё же нужны (прокси, вебхук, подпись которого покрывает точное содержимое, свой бинарный формат), Волга даёт доступ к телу запроса как есть.
+
+## Чтение тела в байты
+
+Начиная с **v0.9.4**, [`HttpBody`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html) является экстрактором — достаточно объявить его аргументом обработчика, чтобы получить сырое тело запроса:
+
+```toml
+[dependencies]
+volga = { version = "..." }
+tokio = { version = "...", features = ["full"] }
+http-body-util = "0.1"
+```
+
+```rust
+use http_body_util::BodyExt;
+use volga::{App, HttpBody, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_post("/raw", |body: HttpBody| async move {
+        let bytes = body.collect().await?.to_bytes();
+        ok!(format!("received {} bytes", bytes.len()))
+    });
+
+    app.run().await
+}
+```
+
+Для сборки тела нужны методы трейта [`Body`](https://docs.rs/http-body/latest/http_body/trait.Body.html), которые приходят из расширяющего трейта [`BodyExt`](https://docs.rs/http-body-util/latest/http_body_util/trait.BodyExt.html) крейта `http-body-util` — Волга его не реэкспортирует.
+
+::: warning
+Тело запроса — это поток, который можно прочитать лишь однажды, поэтому [`HttpBody`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html) нельзя комбинировать с другим экстрактором тела в одном обработчике. Экстракторы, читающие только заголовочную часть запроса — [`Path<T>`](/volga-docs/ru/getting-started/route-params.html), [`Query<T>`](/volga-docs/ru/getting-started/query-params.html), [`HttpHeaders`](/volga-docs/ru/requests-responses/headers.html), [`Dc<T>`](/volga-docs/ru/advanced-patterns/di.html) — сочетаются с ним свободно.
+:::
+
+::: tip
+Ограничение на размер тела продолжает действовать: по умолчанию Волга отклоняет тела больше 5 МБ. Настроить его можно через [`with_body_limit()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_body_limit) или полностью снять через [`without_body_limit()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.without_body_limit).
+:::
+
+## Проброс тела дальше
+
+[`HttpBody`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html) можно и возвращать, поэтому обработчик-транзит сводится к перемещению тела в ответ — ничего не буферизуется:
+
+```rust
+use volga::{App, HttpBody, HttpResponse, headers::ContentType};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_post("/trace", |body: HttpBody| async move {
+        HttpResponse::builder()
+            .status(200)
+            .header(ContentType::multipart_form_data("X-BOUNDARY"))
+            .body(body)
+    });
+
+    app.run().await
+}
+```
+
+## Потоковая обработка тела
+
+Чтобы обрабатывать тело по мере поступления, а не собирать его целиком, используйте [`HttpBodyStream`](https://docs.rs/volga/latest/volga/http/body/type.HttpBodyStream.html) — это [`ByteStream`](https://docs.rs/volga/latest/volga/http/endpoints/args/byte_stream/struct.ByteStream.html) поверх тела запроса, реализующий [`Stream<Item = Result<Bytes, Error>>`](https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html):
+
+```toml
+[dependencies]
+volga = { version = "..." }
+tokio = { version = "...", features = ["full"] }
+futures-util = "0.3"
+```
+
+```rust
+use futures_util::StreamExt;
+use volga::{App, http::HttpBodyStream, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.map_post("/count", |mut stream: HttpBodyStream| async move {
+        let mut total = 0;
+        while let Some(chunk) = stream.next().await {
+            total += chunk?.len();
+        }
+        ok!(format!("received {total} bytes"))
+    });
+
+    app.run().await
+}
+```
+
+Такой подход подходит для тел, которые не хочется держать в памяти целиком: подсчёт хеша загрузки, пересылка чанков в хранилище, разбор построчного потока.
+
+## Создание тела
+
+Тот же тип используется и для построения тел ответа — именно это делают макросы семейства [`ok!`](https://docs.rs/volga/latest/volga/macro.ok.html) под капотом:
+
+| Конструктор | Что создаёт |
+|---|---|
+| [`HttpBody::full`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.full) | готовое тело в памяти из всего, что преобразуется в `Bytes` |
+| [`HttpBody::empty`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.empty) | пустое тело |
+| [`HttpBody::json`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.json) / [`form`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.form) | сериализованное тело JSON или формы |
+| [`HttpBody::file`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.file) | потоковое тело поверх открытого файла |
+| [`HttpBody::stream`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.stream) / [`stream_bytes`](https://docs.rs/volga/latest/volga/http/body/struct.HttpBody.html#method.stream_bytes) | потоковое тело поверх любого `Stream` |
+
+## Примеры
+
+Проброс сырого тела можно посмотреть в [примере с multipart](https://github.com/RomanEmreis/volga/blob/main/examples/multipart/src/main.rs).

--- a/docs/ru/requests-responses/cookie.md
+++ b/docs/ru/requests-responses/cookie.md
@@ -20,7 +20,7 @@ cookie = "0.18.1"
 
 ## Пример использования
 
-```rust
+```rust compile
 use volga::{
     App, HttpResult,
     http::Cookies,
@@ -122,7 +122,7 @@ volga = { version = "...", features = ["cookie-full", "di"] }
 
 Подписанные и закрыте файлы cookie требуют секретных ключей, предоставляемых через DI:
 
-```rust
+```rust compile-fragment
 use volga::http::SignedKey;
 
 app.add_singleton(SignedKey::generate());
@@ -130,7 +130,7 @@ app.add_singleton(SignedKey::generate());
 
 Alternatively, for private cookies:
 
-```rust
+```rust compile-fragment
 use volga::http::PrivateKey;
 
 app.add_singleton(PrivateKey::generate());

--- a/docs/ru/requests-responses/files.md
+++ b/docs/ru/requests-responses/files.md
@@ -7,7 +7,7 @@
 
 ### Использование `file!`
 Макрос `file!` предлагает удобный синтаксис для отправки файла:
-```rust
+```rust compile
 use volga::{App, file};
 use tokio::fs::File;
 
@@ -34,7 +34,7 @@ async fn main() -> std::io::Result<()> {
 
 ### Пример загрузки файла
 Пример настройки маршрута для обработки загрузки файлов:
-```rust
+```rust compile
 use volga::{App, File};
 
 #[tokio::main]
@@ -60,7 +60,7 @@ volga = { version = "...", features = ["multipart"] }
 ```
 ### Пример загрузки нескольких файлов
 Пример, демонстрирующий многокомпонентную загрузку файлов:
-```rust
+```rust compile
 use volga::{App, Multipart};
 
 #[tokio::main]

--- a/docs/ru/requests-responses/form.md
+++ b/docs/ru/requests-responses/form.md
@@ -4,7 +4,7 @@
 
 ## Получение Form Data
 Для принятия данных формы в теле запросе и десериализации его в строго типизированную сущность, используйте структуру [`Form<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/form/struct.Form.html). Где `T` должен быть десериализуемый тип, либо [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html). В случае своей структуры убедитесь, что она реализует [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) из [serde](https://crates.io/crates/serde):
-```rust
+```rust compile
 use volga::{App, Form, ok};
 use serde::Deserialize;
  
@@ -38,7 +38,7 @@ Hello John!
 
 ## Отправка Form Data
 Чтобы отправить ответ с данными формы, вы можете использовать макрос [`form!`](https://docs.rs/volga/latest/volga/macro.form.html):
-```rust
+```rust compile
 use volga::{App, Form, form};
 use serde::Serialize;
  
@@ -65,7 +65,7 @@ async fn main() -> std::io::Result<()> {
 ```
 В качестве альтернативы, указав [`Form<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/form/struct.Form.html) в качестве возвращаемого типа, вы можете вернуть структуру вашего типа напрямую, благодаря типажу [`IntoResponse`](https://docs.rs/volga/latest/volga/http/response/into_response/trait.IntoResponse.html):
 
-```rust
+```rust compile
 use volga::{App, Form};
 use serde::Serialize;
  

--- a/docs/ru/requests-responses/headers.md
+++ b/docs/ru/requests-responses/headers.md
@@ -7,7 +7,7 @@
 Вы можете извлечь определённый заголовок из запроса с помощью [`Header<T>`](https://docs.rs/volga/latest/volga/headers/header/struct.Header.html) или получить все заголовки в виде [`HttpHeaders`](https://docs.rs/volga/latest/volga/headers/header/struct.HttpHeaders.html) — снимка, доступного только для чтения.
 
 ### Использование `Header<T>`
-```rust
+```rust compile
 use volga::{App, ok};
 use volga::headers::{Header, ContentType};
 
@@ -65,7 +65,7 @@ Received x-api-key: 123-321
 
 ### Упрощение работы с кастомными заголовками с помощью макроса `headers!`
 Вместо реализации типажа вручную, вы можете использовать макрос [`headers!`](https://docs.rs/volga/latest/volga/macro.headers.html):
-```rust
+```rust compile
 use volga::{App, ok};
 use volga::headers::{
     Header,
@@ -97,7 +97,7 @@ Received x-api-key: 123-321; correlation-id: 456-654
 
 ### Использование `HttpHeaders`
 Альтернативный способ с помощью структуры [`HttpHeaders`](https://docs.rs/volga/latest/volga/headers/header/struct.HttpHeaders.html):
-```rust
+```rust compile
 use volga::{App, ok};
 use volga::headers::HttpHeaders;
 

--- a/docs/ru/requests-responses/json-payload.md
+++ b/docs/ru/requests-responses/json-payload.md
@@ -4,7 +4,7 @@
 
 ## Получение JSON
 Чтобы принять JSON в теле запроса и десериализовать его в строго типизированную сущность, используйте структуру [`Json<T>`](https://docs.rs/volga/latest/volga/http/endpoints/args/json/struct.Json.html). Тип `T` должен быть десериализуемой структурой, поэтому убедитесь, что он реализует типаж [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) из [serde](https://crates.io/crates/serde):
-```rust
+```rust compile
 use volga::{App, Json, ok};
 use serde::Deserialize;
 
@@ -38,7 +38,7 @@ curl -X POST "http://127.0.0.1:7878/hello" -H "Content-Type: application/json" -
 
 ## Отправка JSON
 Для отправки ответов в формате JSON Волга предоставляет макрос [`ok!`](https://docs.rs/volga/latest/volga/macro.ok.html):
-```rust
+```rust compile
 use volga::{App, ok};
 use serde::Serialize;
 
@@ -87,7 +87,7 @@ async fn main() -> std::io::Result<()> {
 ```
 ### Указание статуса вместе с JSON
 Вы также можете включать HTTP-статусы в ваши JSON-ответы с помощью макроса [`status!`](https://docs.rs/volga/latest/volga/macro.status.html):
-```rust
+```rust compile
 use volga::{App, status};
 use serde::Serialize;
 

--- a/docs/ru/requests-responses/multipart.md
+++ b/docs/ru/requests-responses/multipart.md
@@ -17,7 +17,7 @@ volga = { version = "...", features = ["multipart"] }
 ## Возврат multipart-ответа
 
 Самый простой способ собрать исходящий multipart — функция [`Multipart::from_parts`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Multipart.html#method.from_parts), принимающая любой `IntoIterator<Item = Part>`:
-```rust
+```rust compile
 use volga::{App, Multipart, multipart::Part};
 
 #[tokio::main]
@@ -53,7 +53,7 @@ async fn main() -> std::io::Result<()> {
 У каждого билдера есть отказоустойчивый аналог `try_*` (`try_text`, `try_bytes`, `try_file`, `try_stream`, `try_with_disposition`) — конструкторы для статических входных данных паникуют при некорректных байтах в заголовках, а варианты `try_*` стоит использовать, когда имя поля или имя файла приходят из недоверенных источников.
 
 Типичный пример со смешанным содержимым — текстовое поле и файл в памяти:
-```rust
+```rust compile
 use bytes::Bytes;
 use volga::{App, Multipart, multipart::Part};
 
@@ -75,7 +75,7 @@ async fn main() -> std::io::Result<()> {
 ## Потоковые части
 
 Если тело части большое или формируется постепенно, используйте [`Part::stream`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Part.html#method.stream) — оно отправится без буферизации. Тело должно быть `Stream<Item = Result<Bytes, volga::error::Error>>`:
-```rust
+```rust compile
 use bytes::Bytes;
 use futures_util::{StreamExt, stream};
 use volga::{App, Multipart, multipart::Part};
@@ -110,7 +110,7 @@ async fn main() -> std::io::Result<()> {
 ## Выбор подтипа
 
 По умолчанию исходящий multipart использует подтип `multipart/form-data`. Чтобы переключиться на `mixed`, `byteranges` или любой другой подтип из RFC 2046, вызовите [`Multipart::with_subtype`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Multipart.html#method.with_subtype):
-```rust
+```rust compile
 use bytes::Bytes;
 use volga::{App, Multipart, multipart::{MultipartSubtype, Part}};
 use volga::headers::{ContentType, HeaderName, HeaderValue};
@@ -150,7 +150,7 @@ async fn main() -> std::io::Result<()> {
 ## Свой boundary
 
 Boundary генерируется автоматически и соответствует RFC 2046 §5.1.1. Чтобы зафиксировать его (полезно в тестах или при работе со строгими клиентами), используйте [`Multipart::with_boundary`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Multipart.html#method.with_boundary). Метод проверяет значение и возвращает ошибку, если boundary некорректен:
-```rust
+```rust compile
 use volga::{App, Multipart, multipart::Part};
 
 #[tokio::main]
@@ -169,7 +169,7 @@ async fn main() -> std::io::Result<()> {
 ## Проксирование входящего multipart
 
 Когда нужно проксировать или переслать входящее multipart-тело обратно клиенту, используйте [`Multipart::into_outgoing`](https://docs.rs/volga/latest/volga/http/endpoints/args/multipart/struct.Multipart.html#method.into_outgoing). Метод перекодирует входящий multipart в исходящий потоковый — каждое поле превращается в `Part` с потоковым телом:
-```rust
+```rust compile
 use volga::{App, Multipart};
 
 #[tokio::main]

--- a/docs/ru/security-access/auth.md
+++ b/docs/ru/security-access/auth.md
@@ -209,7 +209,7 @@ struct Claims {
 
 Вместо настройки статического ключа сервер ресурсов может валидировать Bearer-токены по опубликованным ключам OAuth 2.1 / OIDC-эмитента — без общего секрета. Опишите эмитента через [`with_oauth(...)`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth) и подключите через [`use_oauth()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth):
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .with_bearer_auth(|auth| auth.with_aud(["https://api.example.com"]))
     .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"));

--- a/docs/ru/security-access/auth.md
+++ b/docs/ru/security-access/auth.md
@@ -156,6 +156,8 @@ let mut app = App::new()
 
 ::: info
 `EncodingKey`, `DecodingKey` и `Algorithm` теперь являются собственными типами Волги (больше не реэкспортируются из `jsonwebtoken`). Пути импорта остались прежними (`volga::auth::{EncodingKey, DecodingKey}`), но `jsonwebtoken::ErrorKind` больше недоступен — используйте конструкторы PEM / base64 / secret / env / file, предоставляемые Волгой. Параметры валидации токена настраиваются через [`BearerAuthConfig`](https://docs.rs/volga/latest/volga/auth/bearer/struct.BearerAuthConfig.html); прежний доступ через `BearerTokenService::validation()` удалён.
+
+Начиная с **v0.9.8**, `volga::auth::Algorithm` — это реэкспорт [`JwsAlgorithm`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/enum.JwsAlgorithm.html) из `volga-oauth-core`: варианты, значение по-умолчанию `HS256` и поведение не изменились, но теперь тип общий с клиентскими крейтами — утверждение `private_key_jwt` и bearer-токен, который выпускает сервер, описываются одним словарём. Он также реэкспортируется из `volga::auth::oauth`, где его можно назвать без флага `jwt-auth`.
 :::
 
 ### Использование JWT

--- a/docs/ru/security-access/dpop.md
+++ b/docs/ru/security-access/dpop.md
@@ -1,0 +1,161 @@
+# DPoP — токены, привязанные к отправителю
+
+Bearer-токен — это пароль: им может воспользоваться любой, кто его держит. DPoP (RFC 9449) привязывает токен к ключу, которым владеет клиент, и каждый запрос несёт свежеподписанное доказательство владения — поэтому токен, утёкший из лога, прокси или скомпрометированного хранилища, без ключа ничего не стоит.
+
+Доступно с **v0.9.8** под флагом `dpop` крейта `volga-oauth-client`:
+
+```toml
+[dependencies]
+volga-oauth-client = { version = "...", features = ["dpop"] }
+```
+
+::: info
+Флаг выключен по-умолчанию, потому что подпись — единственная часть крейта, которой нужен бэкенд JWS. Он независим от `private-key-jwt`: учётные данные клиента говорят, **кто попросил** токен, а доказательство DPoP — **кто им владеет**, и один запрос может нести оба.
+:::
+
+## Ключ
+
+[`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html) — это ключ плюс состояние nonce тех серверов, с которыми он общается. [`generate()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.generate) создаёт одноразовый ключ `ES256` — алгоритм, который поддерживает любая реализация DPoP:
+
+```rust
+use volga_oauth_client::{ClientError, Dpop, OAuthClient};
+
+fn build() -> Result<(), ClientError> {
+    let dpop = Dpop::generate()?;
+
+    let client = OAuthClient::new("my-client")
+        .with_secret("s3cret")
+        .with_dpop(dpop.clone());
+
+    // тот же ключ защищает запросы к ресурсу, выполняемые с его токенами
+    let jkt = dpop.thumbprint();
+    Ok(())
+}
+```
+
+Обычное время жизни — **один ключ на сессию**, а не на процесс: его потеря не стоит ничего, кроме привязанных к нему токенов, которые без него всё равно бесполезны. [`generate_with`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.generate_with) умеет также `ES384` и `EdDSA`; RSA-ключи генерируются слишком медленно для «одного на сессию», поэтому их можно только загрузить.
+
+Для ключа, живущего дольше процесса — например, такого, чей отпечаток уже сообщён ресурсу — используйте [`from_pem`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.from_pem) или [`from_pem_file`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.from_pem_file): открытая половина передаётся явно, и при создании обе половины сверяются одной подписью — так несогласованная пара отклоняется сразу, а не приводит к удалённому отказу на каждом подписанном ею запросе.
+
+Клонирование [`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html) разделяет и ключ, **и** nonce, поэтому клиент и код, выполняющий запросы к ресурсу с его токенами, остаются согласованными.
+
+## Получение привязанных токенов
+
+[`with_dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.with_dpop) добавляет доказательство к каждому запросу токена, каким бы грантом он ни отправлялся — Authorization Code, [client credentials, JWT bearer или обмен токенов](/volga-docs/ru/security-access/machine-to-machine.html). Остальное берёт на себя крейт:
+
+* алгоритм проверяется по `dpop_signing_alg_values_supported` до отправки запроса;
+* запрос авторизации называет ключ в `dpop_jkt` (RFC 9449 §10), привязывая к нему код, так что украденный код никто другой не обменяет;
+* отказ `use_dpop_nonce` (§8.2) отрабатывается ровно одним повтором запроса с тем nonce, которого этот отказ потребовал;
+* токены возвращаются с `token_type: DPoP`.
+
+```rust
+use volga_oauth_client::{AuthorizationServerMetadata, ClientError, Dpop, OAuthClient};
+
+async fn tokens(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
+    let dpop = Dpop::generate()?;
+
+    let tokens = OAuthClient::new("my-service")
+        .with_secret("s3cret")
+        .with_dpop(dpop.clone())
+        .client_credentials(metadata)
+        .with_scopes(["inventory:read"])
+        .send()
+        .await?;
+
+    assert!(tokens.is_dpop());
+    assert_eq!(tokens.dpop_jkt.as_deref(), Some(dpop.thumbprint()));
+    Ok(())
+}
+```
+
+::: warning
+Токен, вернувшийся **не** как `DPoP`, отклоняется, а не отдаётся вызывающей стороне и хранилищу как непривязанные учётные данные: сервер без поддержки DPoP просто игнорирует доказательство, и молчаливое согласие на bearer-токен свело бы на нет ту самую привязку, ради которой ключ и заводился.
+:::
+
+[`TokenSet::is_dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html#method.is_dpop) и [`TokenSet::dpop_jkt`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html#structfield.dpop_jkt) сообщают привязку, записанную клиентом, который получил токен. [`TokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.TokenStore.html) живёт дольше процесса, а сгенерированный ключ — нет, поэтому сохранённая запись сверяется с имеющимся ключом перед выдачей: запись, привязанная к ключу, владение которым клиент доказать не может, бесполезна, каким бы неистёкшим ни выглядел токен. Это не ошибка, а устаревший кеш — запись удаляется, и вместо неё запрашивается подходящий токен.
+
+## Защита запросов к ресурсу
+
+Запросы к ресурсу остаются за вами: крейт выпускает доказательства и владеет состоянием nonce, но не становится HTTP-клиентом вместо вас. [`authorize`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize) заполняет оба заголовка — учётные данные `Authorization: DPoP <token>` и доказательство `DPoP`, покрывающее их:
+
+```rust
+use http::{HeaderMap, Method};
+use volga_oauth_client::{ClientError, Dpop, TokenSet};
+
+fn protect(dpop: &Dpop, url: &str, tokens: &TokenSet) -> Result<(), ClientError> {
+    let mut headers = HeaderMap::new();
+    let sent = dpop.authorize(&mut headers, &Method::GET, url, tokens)?;
+
+    // ...отправляем запрос с этими заголовками
+    Ok(())
+}
+```
+
+Доказательство несёт `typ: dpop+jwt`, открытый ключ **по значению** в заголовке `jwk` (никогда по `kid`, в отличие от клиентского утверждения), claims `htm` / `htu` / `iat` / `jti`, а также `ath` — хеш токена доступа — на каждом запросе, который этот токен предъявляет. Из `htu` отбрасываются строка запроса и фрагмент.
+
+::: warning
+[`authorize`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize) отклоняет токен, который этот ключ предъявить не может — bearer-токен или токен, чья записанная привязка называет другой ключ — *до* запроса, вместо того чтобы ресурс отклонял каждый такой запрос.
+:::
+
+Когда `authorize` не подходит по форме, есть два более низкоуровневых инструмента:
+
+* [`proof`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.proof) собирает доказательство вручную — [`with_access_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DpopProof.html#method.with_access_token), [`with_nonce`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DpopProof.html#method.with_nonce), затем [`sign`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DpopProof.html#method.sign);
+* [`thumbprint`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.thumbprint) — это `jkt` (RFC 7638), к которому сервер авторизации привязывает токен; его и передают ресурсу, если ключи фиксируются вне протокола.
+
+## Nonce
+
+Сервер может потребовать, чтобы доказательства несли выбранный им nonce. Раунд с token-эндпоинтом обрабатывается внутри, а раунд с ресурсом — за вами, ведь эти запросы отправляете вы:
+
+```rust
+use http::{HeaderMap, Method};
+use volga_oauth_client::{ClientError, Dpop, TokenSet};
+
+fn with_retry(dpop: &Dpop, url: &str, tokens: &TokenSet) -> Result<(), ClientError> {
+    let mut headers = HeaderMap::new();
+    let sent = dpop.authorize(&mut headers, &Method::GET, url, tokens)?;
+
+    // ...отправляем запрос; затем, получив отказ `use_dpop_nonce`:
+    let response_headers = HeaderMap::new();
+    if let Some(demanded) = dpop.accept_nonce(url, &response_headers)
+        && Some(demanded.as_str()) != sent.as_deref()
+    {
+        dpop.authorize_with_nonce(&mut headers, &Method::GET, url, tokens, &demanded)?;
+        // ...и отправляем ещё раз
+    }
+
+    Ok(())
+}
+```
+
+* [`authorize`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize) возвращает nonce, который реально нёс только что подписанный им proof — разрешение и подпись здесь один шаг, чего не гарантировал бы отдельный запрос значения, пока к тому же origin летят другие запросы.
+* [`accept_nonce`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.accept_nonce) принимает nonce любого ответа и возвращает его.
+* [`authorize_with_nonce`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize_with_nonce) кладёт в повтор именно этот nonce, что бы за это время ни успело измениться в общем состоянии.
+
+::: info
+Nonce запоминаются по origin **и** по пространству имён: token-эндпоинт (§8) и защищённый ресурс (§9) выдают независимые последовательности даже когда их обслуживает один хост, поэтому один только origin ключом быть не может.
+:::
+
+## Чтение DPoP-челленджа
+
+Защищённый по DPoP ресурс отвечает `401` с челленджем `WWW-Authenticate: DPoP ...`, у которого `error` и `error_description` — те же, что в RFC 6750. Начиная с **v0.9.8**, [`BearerChallenge::parse_scheme`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.BearerChallenge.html#method.parse_scheme) читает челлендж для любой схемы:
+
+```rust
+use volga_oauth_client::{BearerChallenge, OAuthError, auth_scheme};
+
+fn read(header: &str) -> Result<(), OAuthError> {
+    let challenge = BearerChallenge::parse_scheme(header, auth_scheme::DPOP)?;
+    Ok(())
+}
+```
+
+[`with_scheme`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.BearerChallenge.html#method.with_scheme) и [`scheme`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.BearerChallenge.html#method.scheme) отображают и сообщают схему, поэтому разобранный челлендж рендерится обратно в той схеме, в которой пришёл. `parse` — это тот же метод с `auth_scheme::BEARER`.
+
+Оба зарегистрированных кода ошибок DPoP тоже смоделированы: `OAuthErrorCode::UseDpopNonce` и `OAuthErrorCode::InvalidDpopProof` (RFC 9449 §7.1) — раньше они попадали в `Other`.
+
+::: warning
+При обновлении стоит проверить три изменения из **v0.9.8**:
+
+* `OAuthErrorCode` помечен `#[non_exhaustive]`, поэтому ничего не перестанет компилироваться — но код, сопоставлявший два кода DPoP как `Other(..)`, больше их не поймает. Представление на проводе, `as_str` и serde-представление не изменились.
+* У [`TokenSet`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html) появилось поле `dpop_jkt`, поэтому код, собирающий его структурным литералом, обязан его указать (`None` для bearer-токена). Для всего, что не несёт привязки, представление на проводе не изменилось, так что сохранённая ранней версией запись по-прежнему читается.
+* [`ClientAuthMethod`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientAuthMethod.html) больше не `Copy` — новый вариант `PrivateKeyJwt` несёт ключ подписи. `Clone`, `Debug`, `PartialEq` и `Eq` сохранены.
+:::

--- a/docs/ru/security-access/dpop.md
+++ b/docs/ru/security-access/dpop.md
@@ -17,7 +17,7 @@ volga-oauth-client = { version = "...", features = ["dpop"] }
 
 [`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html) — это ключ плюс состояние nonce тех серверов, с которыми он общается. [`generate()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.generate) создаёт одноразовый ключ `ES256` — алгоритм, который поддерживает любая реализация DPoP:
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, Dpop, OAuthClient};
 
 fn build() -> Result<(), ClientError> {
@@ -48,7 +48,7 @@ fn build() -> Result<(), ClientError> {
 * отказ `use_dpop_nonce` (§8.2) отрабатывается ровно одним повтором запроса с тем nonce, которого этот отказ потребовал;
 * токены возвращаются с `token_type: DPoP`.
 
-```rust
+```rust compile
 use volga_oauth_client::{AuthorizationServerMetadata, ClientError, Dpop, OAuthClient};
 
 async fn tokens(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
@@ -78,7 +78,7 @@ async fn tokens(metadata: &AuthorizationServerMetadata) -> Result<(), ClientErro
 
 Запросы к ресурсу остаются за вами: крейт выпускает доказательства и владеет состоянием nonce, но не становится HTTP-клиентом вместо вас. [`authorize`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html#method.authorize) заполняет оба заголовка — учётные данные `Authorization: DPoP <token>` и доказательство `DPoP`, покрывающее их:
 
-```rust
+```rust compile
 use http::{HeaderMap, Method};
 use volga_oauth_client::{ClientError, Dpop, TokenSet};
 
@@ -106,7 +106,7 @@ fn protect(dpop: &Dpop, url: &str, tokens: &TokenSet) -> Result<(), ClientError>
 
 Сервер может потребовать, чтобы доказательства несли выбранный им nonce. Раунд с token-эндпоинтом обрабатывается внутри, а раунд с ресурсом — за вами, ведь эти запросы отправляете вы:
 
-```rust
+```rust compile
 use http::{HeaderMap, Method};
 use volga_oauth_client::{ClientError, Dpop, TokenSet};
 
@@ -139,7 +139,7 @@ Nonce запоминаются по origin **и** по пространству 
 
 Защищённый по DPoP ресурс отвечает `401` с челленджем `WWW-Authenticate: DPoP ...`, у которого `error` и `error_description` — те же, что в RFC 6750. Начиная с **v0.9.8**, [`BearerChallenge::parse_scheme`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.BearerChallenge.html#method.parse_scheme) читает челлендж для любой схемы:
 
-```rust
+```rust compile
 use volga_oauth_client::{BearerChallenge, OAuthError, auth_scheme};
 
 fn read(header: &str) -> Result<(), OAuthError> {

--- a/docs/ru/security-access/machine-to-machine.md
+++ b/docs/ru/security-access/machine-to-machine.md
@@ -1,0 +1,152 @@
+# Гранты «сервис-сервис»
+
+[Флоу Authorization Code](/volga-docs/ru/security-access/oauth-client.html#authorization-code-pkce) существует, чтобы получить токен *от имени пользователя*. Но в изрядной части трафика пользователя нет вовсе: фоновый воркер, вызывающий внутренний API, планировщик задач, сервис, которому нужен токен для самого себя. Начиная с **v0.9.8**, `volga-oauth-client` реализует три гранта для таких случаев — где субъектом является сам клиент.
+
+Все три оформлены как построители на [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html), принимают одни и те же опции [`with_scopes`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.with_scopes) / [`with_resource`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.with_resource) (RFC 8707) / [`with_param`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.with_param) и отправляются через `send()`:
+
+| Метод | Грант | Когда применять |
+|---|---|---|
+| [`client_credentials`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.client_credentials) | RFC 6749 §4.4 | сервис действует от своего имени, со своими учётными данными |
+| [`jwt_bearer`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.jwt_bearer) | RFC 7523 §2.1 | другой авторитет уже выдал JWT, который за него ручается |
+| [`exchange_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.exchange_token) | RFC 8693 | один токен нужно обменять на другой |
+
+::: tip
+Этим грантам нужна [аутентификация клиента](/volga-docs/ru/security-access/oauth-client.html#аутентификация-клиента) — секрет или ключ `private_key_jwt`. Публичному клиенту предъявить нечего, и любой вменяемый сервер ему откажет.
+:::
+
+## Client Credentials
+
+Базовый грант «сервис-сервис». Запроса авторизации, который нёс бы скоупы, здесь нет, поэтому скоупы указываются в самом запросе токена — либо опускаются, и тогда сервер применяет грант по-умолчанию для этого клиента:
+
+```rust
+use volga_oauth_client::{AuthorizationServerMetadata, ClientError, OAuthClient};
+
+async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
+    let client = OAuthClient::new("my-service").with_secret("s3cret");
+
+    let tokens = client
+        .client_credentials(metadata)
+        .with_scopes(["inventory:read"])
+        .with_resource("https://api.example.com")
+        .send()
+        .await?;
+
+    Ok(())
+}
+```
+
+### Хранение сервисного токена
+
+По RFC 6749 §4.4.3 этот грант **не выдаёт refresh-токен**, поэтому [`OAuthClient::token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.token) нечем обновлять сохранённый токен — обновлением служит повторный запуск самого гранта. Именно это делает [`ClientCredentialsRequest::token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.token): отдаёт сохранённый токен, пока он свежий, и заново выполняет грант — с теми же скоупами и индикаторами ресурсов — когда это уже не так.
+
+```rust
+use std::sync::Arc;
+use volga_oauth_client::{
+    AuthorizationServerMetadata, ClientError, InMemoryTokenStore, OAuthClient,
+};
+
+async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
+    let client = OAuthClient::new("my-service")
+        .with_secret("s3cret")
+        .with_token_store(Arc::new(InMemoryTokenStore::new()));
+
+    // первый вызов делает запрос, остальные обслуживаются из хранилища,
+    // пока токен не приблизится к истечению
+    let tokens = client
+        .client_credentials(metadata)
+        .with_scopes(["inventory:read"])
+        .token("inventory")
+        .await?;
+
+    Ok(())
+}
+```
+
+::: warning
+Сохранённый токен, время жизни которого сервер не сообщил, запрашивается заново, а не отдаётся: `expires_in` по RFC 6749 §5.1 лишь РЕКОМЕНДУЕТСЯ, а неизвестное время жизни не является доказательством свежести. Против сервера, который его не присылает, грант будет выполняться на каждый вызов — это один запрос, а тот, кто всё же хочет кешировать, может держать [`TokenSet`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html) из [`send()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.send) по своей политике.
+
+Метод **паникует**, если [`TokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.TokenStore.html) не подключён.
+:::
+
+## JWT Bearer
+
+Предъявляет JWT в качестве гранта авторизации. Утверждение передаётся вызывающей стороной, а не выпускается здесь: это то, что уже выдал другой авторитет — токен workload-идентичности платформы, на которой работает клиент, или утверждение личности, полученное предыдущим обменом.
+
+```rust
+use volga_oauth_client::{AuthorizationServerMetadata, ClientError, OAuthClient};
+
+async fn run(
+    metadata: &AuthorizationServerMetadata,
+    workload_jwt: &str,
+) -> Result<(), ClientError> {
+    let tokens = OAuthClient::new("my-workload")
+        .jwt_bearer(metadata, workload_jwt)
+        .with_scopes(["inventory:read"])
+        .send()
+        .await?;
+
+    Ok(())
+}
+```
+
+::: warning
+Отказ здесь окончателен: утверждение либо принимается, либо нет. Не повторяйте запрос и не переключайтесь на другой тип гранта — чините само утверждение. `invalid_grant` означает, что отклонено именно оно.
+:::
+
+::: info
+`jwt_bearer` и `private_key_jwt` оба отправляют подписанный JWT, и их легко перепутать. Они отвечают на разные вопросы: **грант** JWT bearer — это *почему* токен должен быть выдан, а клиентское утверждение `private_key_jwt` — *кто просит*. Один запрос может нести оба.
+:::
+
+## Обмен токенов
+
+Меняет один токен на другой (RFC 8693) — грант делегирования и олицетворения. `subject_token` представляет сторону, для которой запрашивается новый токен, а `subject_token_type` определяет, что это такое: одна из констант [`token_type`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/protocol/token_type/index.html) или любой URI, понятный серверу.
+
+```rust
+use volga_oauth_client::{
+    AuthorizationServerMetadata, ClientError, OAuthClient, token_type,
+};
+
+async fn run(
+    idp: &AuthorizationServerMetadata,
+    resource_server: &AuthorizationServerMetadata,
+    id_token: &str,
+) -> Result<(), ClientError> {
+    let client = OAuthClient::new("my-app").with_secret("s3cret");
+
+    // меняем ID-токен пользователя на утверждение, которое примет
+    // сервер авторизации нужного ресурса...
+    let exchanged = client
+        .exchange_token(idp, id_token, token_type::ID_TOKEN)
+        .with_requested_token_type(token_type::ID_JAG)
+        .with_audience("https://api.example.com")
+        .send()
+        .await?;
+
+    // ...и предъявляем его там как грант JWT bearer
+    let tokens = client
+        .jwt_bearer(resource_server, &exchanged.token)
+        .send()
+        .await?;
+
+    Ok(())
+}
+```
+
+В отличие от двух других грантов, обмен может вернуть **не** bearer-токен доступа, поэтому он отвечает типом [`ExchangedToken`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ExchangedToken.html), а не [`TokenSet`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenSet.html):
+
+* `issued_token_type` — что именно решил выдать сервер;
+* [`is_bearer()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ExchangedToken.html#method.is_bearer) — годится ли он как учётные данные `Authorization: Bearer`;
+* [`is_expired()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ExchangedToken.html#method.is_expired) / [`expires_within()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ExchangedToken.html#method.expires_within) — та же работа с абсолютным сроком истечения, что и у `TokenSet`.
+
+Помимо общих опций, запрос принимает [`with_requested_token_type`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenExchangeRequest.html#method.with_requested_token_type), [`with_audience`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenExchangeRequest.html#method.with_audience) и [`with_actor_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.TokenExchangeRequest.html#method.with_actor_token) (делегирование, где действующая сторона указывается рядом с субъектом).
+
+## Что отклоняется до обращения к сети
+
+Все три гранта скорее откажут в запросе, чем отправят заведомо безнадёжный. Грант должны разрешать **обе** стороны:
+
+* сервер обязан перечислить его в `grant_types_supported`;
+* клиент, созданный через [`from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration), должен иметь его в одобренных регистрацией `grant_types`.
+
+Проверка регистрации распространяется и на флоу Authorization Code: `authorization_request().build()` и `exchange_code` откажут, вместо того чтобы отправить пользователя во флоу, который клиент, возможно, не сможет завершить. Отсутствующий `grant_types` означает только `authorization_code` (RFC 7591 §2); неограничен лишь клиент, который вообще не проходил регистрацию, а `refresh_token` не отклоняется никогда.
+
+Оба отказа возвращаются как `ClientError::Validation` — это более внятный сигнал, чем `unauthorized_client`, которым ответил бы token-эндпоинт.

--- a/docs/ru/security-access/machine-to-machine.md
+++ b/docs/ru/security-access/machine-to-machine.md
@@ -18,7 +18,7 @@
 
 Базовый грант «сервис-сервис». Запроса авторизации, который нёс бы скоупы, здесь нет, поэтому скоупы указываются в самом запросе токена — либо опускаются, и тогда сервер применяет грант по-умолчанию для этого клиента:
 
-```rust
+```rust compile
 use volga_oauth_client::{AuthorizationServerMetadata, ClientError, OAuthClient};
 
 async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> {
@@ -39,7 +39,7 @@ async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> 
 
 По RFC 6749 §4.4.3 этот грант **не выдаёт refresh-токен**, поэтому [`OAuthClient::token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.token) нечем обновлять сохранённый токен — обновлением служит повторный запуск самого гранта. Именно это делает [`ClientCredentialsRequest::token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientCredentialsRequest.html#method.token): отдаёт сохранённый токен, пока он свежий, и заново выполняет грант — с теми же скоупами и индикаторами ресурсов — когда это уже не так.
 
-```rust
+```rust compile
 use std::sync::Arc;
 use volga_oauth_client::{
     AuthorizationServerMetadata, ClientError, InMemoryTokenStore, OAuthClient,
@@ -72,7 +72,7 @@ async fn run(metadata: &AuthorizationServerMetadata) -> Result<(), ClientError> 
 
 Предъявляет JWT в качестве гранта авторизации. Утверждение передаётся вызывающей стороной, а не выпускается здесь: это то, что уже выдал другой авторитет — токен workload-идентичности платформы, на которой работает клиент, или утверждение личности, полученное предыдущим обменом.
 
-```rust
+```rust compile
 use volga_oauth_client::{AuthorizationServerMetadata, ClientError, OAuthClient};
 
 async fn run(
@@ -101,7 +101,7 @@ async fn run(
 
 Меняет один токен на другой (RFC 8693) — грант делегирования и олицетворения. `subject_token` представляет сторону, для которой запрашивается новый токен, а `subject_token_type` определяет, что это такое: одна из констант [`token_type`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/protocol/token_type/index.html) или любой URI, понятный серверу.
 
-```rust
+```rust compile
 use volga_oauth_client::{
     AuthorizationServerMetadata, ClientError, OAuthClient, token_type,
 };

--- a/docs/ru/security-access/oauth-client.md
+++ b/docs/ru/security-access/oauth-client.md
@@ -36,7 +36,7 @@ volga-oauth-client = { version = "..." }
 
 [`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) разрешает well-known discovery-URL, загружает документы по HTTPS и проверяет каждый на соответствие идентификатору, для которого он был запрошен (RFC 8414 §3.3 / RFC 9728 §3.3):
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, DiscoveryClient};
 
 async fn discover() -> Result<(), ClientError> {
@@ -67,7 +67,7 @@ async fn discover() -> Result<(), ClientError> {
 
 [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) реализует флоу OAuth 2.1 Authorization Code. PKCE (S256) генерируется и применяется автоматически — это защита, которую OAuth 2.1 предписывает для публичных клиентов.
 
-```rust
+```rust compile
 use std::sync::Arc;
 use volga_oauth_client::{ClientError, DiscoveryClient, InMemoryTokenStore, OAuthClient};
 
@@ -120,7 +120,7 @@ async fn authorize() -> Result<(), ClientError> {
 
 Начиная с **v0.9.6**, метод [`validate_callback`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.validate_callback) проверяет callback целиком — и `state`, и параметр `iss` из RFC 9207 — и рекомендуется вместо голого `matches_state`:
 
-```rust
+```rust compile
 use volga_oauth_client::{AuthorizationRequest, AuthorizationServerMetadata, ClientError};
 
 fn check(
@@ -150,7 +150,7 @@ fn check(
 
 ### Общий секрет
 
-```rust
+```rust compile-fragment
 use volga_oauth_client::{ClientAuthMethod, OAuthClient};
 
 let client = OAuthClient::new("my-client")
@@ -163,7 +163,7 @@ let client = OAuthClient::new("my-client")
 
 Начиная с **v0.9.8** (флаг `private-key-jwt`), клиент может аутентифицироваться утверждением, подписанным его собственным ключом (RFC 7523 §2.2) — при этом общий секрет никогда не покидает клиент:
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, JwsAlgorithm, OAuthClient, PrivateKeyJwt};
 
 fn build() -> Result<OAuthClient, ClientError> {
@@ -184,7 +184,7 @@ fn build() -> Result<OAuthClient, ClientError> {
 
 Сервер авторизации проверяет утверждения открытой половиной ключа, которую он либо забирает по `jwks_uri`, либо получил при регистрации. [`with_public_jwk`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_public_jwk) прикрепляет её, а [`jwks()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.jwks) формирует документ для публикации:
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, JwsAlgorithm, PrivateKeyJwt, PublicJwk};
 
 fn publish(key: PrivateKeyJwt, public: PublicJwk) -> Result<(), ClientError> {
@@ -215,7 +215,7 @@ fn publish(key: PrivateKeyJwt, public: PublicJwk) -> Result<(), ClientError> {
 
 Сохранение выполняется через трейт [`TokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/trait.TokenStore.html). [`InMemoryTokenStore`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.InMemoryTokenStore.html) — встроенная реализация в памяти процесса, подходящая для CLI, тестов и одноинстансовых сервисов; всё долговременное (БД, зашифрованный файл, связка ключей ОС) реализуется одной реализацией трейта.
 
-```rust
+```rust compile
 use volga_oauth_client::{TokenSet, TokenStore};
 
 struct MyStore;
@@ -233,7 +233,7 @@ impl TokenStore for MyStore {
 
 [`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) отправляет [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientMetadata.html) на registration-эндпоинт сервера (RFC 7591) и возвращает выданные учётные данные. [`OAuthClient::from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration) принимает их и создаёт готовый к использованию клиент:
 
-```rust
+```rust compile
 use volga_oauth_client::{
     ClientError, ClientMetadata, DiscoveryClient, OAuthClient, RegistrationClient,
 };
@@ -267,7 +267,7 @@ async fn register() -> Result<(), ClientError> {
 
 Если регистрация использует `private_key_jwt`, принимайте её через [`from_registration_with_key`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration_with_key) — он также отклонит ключ, который регистрация не приняла бы: подписывающий алгоритмом, отличным от зарегистрированного `token_endpoint_auth_signing_alg`, или с `kid`, который не разрешается встроенным `jwks`:
 
-```rust
+```rust compile
 use volga_oauth_client::{ClientError, ClientRegistrationResponse, OAuthClient, PrivateKeyJwt};
 
 fn adopt(
@@ -290,7 +290,7 @@ fn adopt(
 
 [`ClientConfig`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientConfig.html) несёт политику, общую для всех операций клиента — принудительный HTTPS, таймауты на запрос и лимиты редиректов. Значения по-умолчанию безопасны для продакшена; чаще всего переопределяют отключение HTTPS для локального сервера разработки:
 
-```rust
+```rust compile-fragment
 use std::time::Duration;
 use volga_oauth_client::{ClientConfig, OAuthClient};
 
@@ -308,7 +308,7 @@ let client = OAuthClient::new("my-client").with_config(config);
 
 Начиная с **v0.9.8**, при включённом на `volga` флаге `oauth-client`, [`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) преобразуется в [`volga::Error`](https://docs.rs/volga/latest/volga/error/struct.Error.html), поэтому обработчик, общающийся с сервером авторизации, может пробрасывать ошибку через `?`:
 
-```rust
+```rust compile
 use volga::{HttpResult, ok};
 use volga_oauth_client::{DiscoveryClient};
 

--- a/docs/ru/security-access/oauth-client.md
+++ b/docs/ru/security-access/oauth-client.md
@@ -5,8 +5,10 @@
 Он предоставляет три клиента, разделяющих транспортную политику [`ClientConfig`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientConfig.html) и модель ошибок [`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html):
 
 * [`DiscoveryClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.DiscoveryClient.html) — загружает Authorization Server Metadata (RFC 8414), Protected Resource Metadata (RFC 9728) и конфигурацию провайдера OpenID Connect.
-* [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) — флоу Authorization Code с обязательным PKCE, refresh-токенами и индикаторами ресурсов, плюс сохранение токенов.
+* [`OAuthClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html) — флоу Authorization Code с обязательным PKCE, refresh-токенами и индикаторами ресурсов, плюс сохранение токенов. С **v0.9.8** он также реализует гранты, аутентифицирующие *сам клиент* — см. [Гранты «сервис-сервис»](/volga-docs/ru/security-access/machine-to-machine.html).
 * [`RegistrationClient`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html) — динамическую регистрацию клиентов (RFC 7591).
+
+С **v0.9.8** полученные токены можно привязать к ключу клиента через [`Dpop`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.Dpop.html) (RFC 9449) — см. [DPoP](/volga-docs/ru/security-access/dpop.html).
 
 ## Зависимости
 
@@ -21,8 +23,14 @@ volga-oauth-client = { version = "..." }
 |---|---|
 | `http1` (по-умолчанию) | HTTP/1.1 через hyper |
 | `http2` | HTTP/2 через hyper; согласуется через TLS ALPN при совместном использовании с `http1`, либо используется эксклюзивно (prior knowledge поверх plaintext) без него |
+| `private-key-jwt` | аутентификацию клиента `private_key_jwt` (RFC 7523 §2.2) — клиентское утверждение, подписанное собственным ключом клиента |
+| `dpop` | токены, привязанные к отправителю, по DPoP (RFC 9449) |
 
-Как минимум один из двух должен быть включён.
+Как минимум один из `http1` / `http2` должен быть включён.
+
+::: info
+`private-key-jwt` и `dpop` выключены по-умолчанию, потому что это единственные части крейта, которым нужен бэкенд подписи JWS (`jsonwebtoken` поверх `aws-lc-rs`). Все гранты, методы аутентификации по секрету и публичные клиенты работают без них.
+:::
 
 ## Discovery
 
@@ -108,13 +116,39 @@ async fn authorize() -> Result<(), ClientError> {
 Всегда проверяйте `state` из callback через [`matches_state`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.matches_state) **до** обмена кода — это ваша защита от CSRF.
 :::
 
+### Валидация callback
+
+Начиная с **v0.9.6**, метод [`validate_callback`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.validate_callback) проверяет callback целиком — и `state`, и параметр `iss` из RFC 9207 — и рекомендуется вместо голого `matches_state`:
+
+```rust
+use volga_oauth_client::{AuthorizationRequest, AuthorizationServerMetadata, ClientError};
+
+fn check(
+    request: &AuthorizationRequest,
+    metadata: &AuthorizationServerMetadata,
+    state: &str,
+    iss: Option<&str>,
+) -> Result<(), ClientError> {
+    request.validate_callback(metadata, state, iss)?;
+    Ok(())
+}
+```
+
+`iss` — это параметр запроса `iss` из callback или `None`, если ответ его не содержал. Он обязан совпадать с издателем, когда присутствует, и становится **обязательным**, как только сервер объявляет `authorization_response_iss_parameter_supported`.
+
+::: warning
+Без проверки `iss` callback можно воспроизвести от *другого* сервера авторизации — это и есть атака подмены (mix-up), ради которой существует RFC 9207. Если провайдер объявляет этот параметр, используйте [`validate_callback`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.validate_callback); [`matches_state`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationRequest.html#method.matches_state) остаётся для проверки только `state`.
+:::
+
 ### Прозрачное обновление
 
 [`token(key, &metadata)`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.token) читает сохранённые токены и незаметно обновляет устаревший access-токен. Он возвращает `Ok(None)`, когда требуется интерактивная авторизация — ничего не сохранено, у записи нет refresh-токена или сервер отклонил refresh-токен (`invalid_grant`); в последних случаях «мёртвая» запись удаляется из хранилища. Можно также обновить явно через [`refresh`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.refresh).
 
-### Конфиденциальные клиенты
+## Аутентификация клиента
 
-Без секрета клиент работает как **публичный клиент** (защитой служит PKCE). Добавьте секрет, чтобы аутентифицироваться на token-эндпоинте:
+Без учётных данных клиент работает как **публичный** (защитой служит PKCE, как и предписывает OAuth 2.1). Конфиденциальный клиент аутентифицируется на token-эндпоинте одним из трёх способов, и выбранный способ применяется ко всем грантам, которые он отправляет.
+
+### Общий секрет
 
 ```rust
 use volga_oauth_client::{ClientAuthMethod, OAuthClient};
@@ -124,6 +158,58 @@ let client = OAuthClient::new("my-client")
     // `client_secret_basic` (по-умолчанию) или `client_secret_post`
     .with_auth_method(ClientAuthMethod::Post);
 ```
+
+### `private_key_jwt`
+
+Начиная с **v0.9.8** (флаг `private-key-jwt`), клиент может аутентифицироваться утверждением, подписанным его собственным ключом (RFC 7523 §2.2) — при этом общий секрет никогда не покидает клиент:
+
+```rust
+use volga_oauth_client::{ClientError, JwsAlgorithm, OAuthClient, PrivateKeyJwt};
+
+fn build() -> Result<OAuthClient, ClientError> {
+    let key = PrivateKeyJwt::from_pem_file("/etc/secrets/client.pem", JwsAlgorithm::RS256)?
+        .with_key_id("2026-08");
+
+    Ok(OAuthClient::new("my-client").with_private_key_jwt(key))
+}
+```
+
+[`PrivateKeyJwt`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html) загружает ключ ([`from_pem`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.from_pem), [`from_pem_file`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.from_pem_file), [`from_der`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.from_der)) и несёт политику claims — [`with_key_id`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_key_id), [`with_lifetime`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_lifetime) (по-умолчанию 60 секунд) и [`with_audiences`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_audiences). На каждый запрос токена выпускается новое утверждение со случайным `jti`, поэтому перехваченное живёт недолго. Подключение ключа отменяет любой [`with_secret`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.with_secret) — учётными данными становится утверждение.
+
+::: warning
+Симметричные алгоритмы отклоняются: HMAC-секрет, который сервер и так знает, ничего не доказывает о том, кто подписал. Алгоритм также проверяется по `token_endpoint_auth_signing_alg_values_supported`, если сервер его объявляет.
+:::
+
+### Публикация открытого ключа
+
+Сервер авторизации проверяет утверждения открытой половиной ключа, которую он либо забирает по `jwks_uri`, либо получил при регистрации. [`with_public_jwk`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.with_public_jwk) прикрепляет её, а [`jwks()`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.PrivateKeyJwt.html#method.jwks) формирует документ для публикации:
+
+```rust
+use volga_oauth_client::{ClientError, JwsAlgorithm, PrivateKeyJwt, PublicJwk};
+
+fn publish(key: PrivateKeyJwt, public: PublicJwk) -> Result<(), ClientError> {
+    let key = key.with_public_jwk(public)?;
+
+    // отдавайте это по вашему `jwks_uri` либо отправьте как поле `jwks`
+    // в запросе динамической регистрации клиента
+    let document = key.jwks();
+    Ok(())
+}
+```
+
+[`PublicJwk`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/jwk/struct.PublicJwk.html) (RFC 7517, из `volga-oauth-core`) моделирует исключительно **открытый** материал подписи — приватные поля в нём выразить нельзя, а десериализация документа, который их несёт, завершается ошибкой, а не молчаливым отбрасыванием. Он также отклоняет сочетания, с которыми не сможет работать ни один проверяющий: RSA-ключ, объявляющий `ES256`, ключ P-384 с `ES256`, открытый ключ с HMAC-алгоритмом или кривую, не принадлежащую типу ключа. Поля `kid` и `alg` заполняются из конфигурации подписи, поэтому опубликованный документ всегда согласован с тем, что реально несут утверждения.
+
+::: info
+Открытый ключ передаётся явно — крейт подписывает, но не выводит открытые ключи из закрытых. Именно это делает невозможной случайную публикацию ключа подписи.
+:::
+
+### Что проверяется до отправки запроса
+
+Начиная с **v0.9.8**, настроенный способ аутентификации проверяется по `token_endpoint_auth_methods_supported` до отправки запроса токена: способ, который сервер не объявлял, принёс бы по сети лишь `invalid_client`. Метаданные, не перечисляющие ни одного способа, под сомнение не ставятся — именно так выглядит [`AuthorizationServerMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.AuthorizationServerMetadata.html), собранный вручную — но *обнаруженный* через discovery документ всегда что-то перечисляет, поскольку по RFC 8414 отсутствие поля означает `client_secret_basic`. Публичный клиент не предъявляет учётных данных и не проверяется.
+
+::: info
+Зарегистрированные идентификаторы протокола, о которых договариваются обе стороны, с **v0.9.8** живут в одном месте — `volga_oauth_core::protocol`, в виде констант `grant`, `client_auth`, `token_type` и `auth_scheme`, реэкспортируемых и из `volga::auth::oauth`, и из `volga_oauth_client`. Сервер объявляет их в своих метаданных, а клиент по ним сопоставляет — так они не могут разойтись.
+:::
 
 ## Хранилище токенов
 
@@ -174,6 +260,28 @@ async fn register() -> Result<(), ClientError> {
 
 Для серверов, не разрешающих открытую регистрацию, добавьте начальный токен доступа через [`with_initial_access_token`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.RegistrationClient.html#method.with_initial_access_token).
 
+Два поля [`ClientMetadata`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.ClientMetadata.html) стали полноценными в **v0.9.6** и **v0.9.8** соответственно:
+
+* [`with_application_type`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.ClientMetadata.html#method.with_application_type) — `"web"` или `"native"`. Десктопные и CLI-клиенты регистрируются как `"native"` — именно это делает loopback-адреса перенаправления (`http://127.0.0.1:{port}/...`) приемлемыми для серверов авторизации.
+* [`with_token_endpoint_auth_signing_alg`](https://docs.rs/volga-oauth-core/latest/volga_oauth_core/struct.ClientMetadata.html#method.with_token_endpoint_auth_signing_alg) — алгоритм, которым именно этот клиент подписывает свои утверждения, для регистрации с `private_key_jwt`.
+
+Если регистрация использует `private_key_jwt`, принимайте её через [`from_registration_with_key`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration_with_key) — он также отклонит ключ, который регистрация не приняла бы: подписывающий алгоритмом, отличным от зарегистрированного `token_endpoint_auth_signing_alg`, или с `kid`, который не разрешается встроенным `jwks`:
+
+```rust
+use volga_oauth_client::{ClientError, ClientRegistrationResponse, OAuthClient, PrivateKeyJwt};
+
+fn adopt(
+    registered: &ClientRegistrationResponse,
+    key: PrivateKeyJwt,
+) -> Result<OAuthClient, ClientError> {
+    OAuthClient::from_registration_with_key(registered, key)
+}
+```
+
+::: warning
+Начиная с **v0.9.8**, клиент, созданный через [`from_registration`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthClient.html#method.from_registration), отклоняет грант, который не был одобрен его регистрацией — до обращения к сети, а не в виде `unauthorized_client` от token-эндпоинта. Отсутствующий `grant_types` означает только `authorization_code` (RFC 7591 §2), а не полную свободу; неограничен лишь клиент, который вообще не проходил регистрацию. `refresh_token` не отклоняется никогда, поскольку по RFC 6749 §6 это продолжение уже полученного гранта.
+:::
+
 ::: info
 Протокол управления RFC 7592 (чтение, обновление и удаление регистрации) не реализован, но пара `registration_access_token` / `registration_client_uri` из ответа доступна для приложений, которым она нужна.
 :::
@@ -194,7 +302,38 @@ let config = ClientConfig::new()
 let client = OAuthClient::new("my-client").with_config(config);
 ```
 
-[`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) отделяет разобранный ответ об ошибке OAuth (`Protocol`, несущий [`OAuthError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthError.html) из RFC 6749 §5.2) от ошибок транспорта, декодирования, небезопасного URL и валидации — так вы можете отличить «сервер ответил `invalid_grant`» от «соединение оборвалось».
+[`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) отделяет разобранный ответ об ошибке OAuth (`Protocol`, несущий [`OAuthError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/struct.OAuthError.html) из RFC 6749 §5.2) от ошибок транспорта, декодирования, небезопасного URL и валидации — так вы можете отличить «сервер ответил `invalid_grant`» от «соединение оборвалось». С **v0.9.8** к ним добавился `Signing` — конфигурация подписи не может создать JWS, нужный запросу: утверждение `private_key_jwt` или доказательство DPoP.
+
+### Проброс ошибок из обработчика
+
+Начиная с **v0.9.8**, при включённом на `volga` флаге `oauth-client`, [`ClientError`](https://docs.rs/volga-oauth-client/latest/volga_oauth_client/enum.ClientError.html) преобразуется в [`volga::Error`](https://docs.rs/volga/latest/volga/error/struct.Error.html), поэтому обработчик, общающийся с сервером авторизации, может пробрасывать ошибку через `?`:
+
+```rust
+use volga::{HttpResult, ok};
+use volga_oauth_client::{DiscoveryClient};
+
+async fn metadata() -> HttpResult {
+    let metadata = DiscoveryClient::new()
+        .fetch_server_metadata("https://auth.example.com")
+        .await?; // ClientError -> volga::Error
+
+    ok!(metadata.issuer)
+}
+```
+
+Статус описывает, **где** произошёл сбой, а не повторяет ответ сервера авторизации — ведь в этом вызове *клиентом* было ваше приложение:
+
+| Сбой | Статус |
+|---|---|
+| до сервера не удалось достучаться (`Transport`) | `503 Service Unavailable` |
+| сервер ответил непригодно — ошибка протокола, неожиданный статус, неразбираемое тело | `502 Bad Gateway` |
+| собственная конфигурация приложения — небезопасный URL, метаданные, не прошедшие валидацию, ключ, которым нельзя подписать | `500 Internal Server Error` |
+
+Чтобы показать вызывающей стороне код ошибки самого сервера авторизации, сопоставляйте `ClientError::Protocol` вместо того, чтобы полагаться на это преобразование.
+
+## Что дальше
+* [Гранты «сервис-сервис»](/volga-docs/ru/security-access/machine-to-machine.html) — `client_credentials`, JWT bearer и обмен токенов, для сценариев без участия пользователя.
+* [DPoP](/volga-docs/ru/security-access/dpop.html) — привязка токенов к ключу клиента, чтобы украденный токен ничего не стоил.
 
 ## Примеры
 * [OAuth Flow](https://github.com/RomanEmreis/volga/blob/main/examples/oauth_flow/src/main.rs) — полный флоу discovery → авторизация → обмен кода → вызов защищённого маршрута, реализованный через `volga-oauth-client`.

--- a/docs/ru/security-access/oauth.md
+++ b/docs/ru/security-access/oauth.md
@@ -22,7 +22,7 @@ volga = { version = "...", features = ["oauth-client"] }
 
 Опишите эмитента через [`with_oauth(...)`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth) и явно активируйте через [`use_oauth()`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth):
 
-```rust
+```rust compile
 use serde::Deserialize;
 use volga::{
     App, ok,
@@ -80,7 +80,7 @@ Claim `iss` автоматически ограничивается настро
 
 Эмитент обязателен; у всего остального есть безопасные для продакшена значения по-умолчанию.
 
-```rust
+```rust compile-fragment
 use std::time::Duration;
 use volga::App;
 
@@ -96,7 +96,7 @@ let app = App::new()
 
 Для локального эмитента, работающего по обычному HTTP, ослабьте транспортную политику:
 
-```rust
+```rust compile-fragment
 let app = App::new()
     .with_oauth(|oauth| oauth
         .with_issuer("http://127.0.0.1:5000")
@@ -123,7 +123,7 @@ max_redirects = 5            # опционально
 
 Настройте через [`with_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth_resource_metadata) (или [`set_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.set_oauth_resource_metadata) для передачи значения целиком, включая сокращение через `&str`-идентификатор) и отдайте через [`use_oauth_resource_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.use_oauth_resource_metadata):
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .with_oauth_resource_metadata(|metadata| metadata
         .with_resource("https://api.example.com")
@@ -141,7 +141,7 @@ app.use_oauth_resource_metadata();
 
 Приложения, которые сами являются сервером авторизации, публикуют свои эндпоинты через [`with_oauth_server_metadata`](https://docs.rs/volga/latest/volga/app/struct.App.html#method.with_oauth_server_metadata) и отдают документ по одному или обоим discovery-путям:
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .with_oauth_server_metadata(|metadata| metadata
         .with_issuer("https://auth.example.com")
@@ -160,7 +160,7 @@ app.use_oauth_server_metadata()  // GET /.well-known/oauth-authorization-server
 
 Два поля, которые стоит назвать отдельно, стали типизированными построителями в **v0.9.6** и **v0.9.8**:
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .with_oauth_server_metadata(|metadata| metadata
         .with_issuer("https://auth.example.com")
@@ -175,7 +175,7 @@ let mut app = App::new()
 
 Оба документа также могут приходить из секций `[oauth.resource]` / `[oauth.server]` файла конфигурации (feature `config`); файл переопределяет предыдущие вызовы построителя. Сокращение `set_*` настраивает минимальный документ только по идентификатору:
 
-```rust
+```rust compile-fragment
 let mut app = App::new()
     .set_oauth_resource_metadata("https://api.example.com")
     .set_oauth_server_metadata("https://auth.example.com");
@@ -188,7 +188,7 @@ app.use_oauth_server_metadata().use_oidc_metadata();
 
 Собирая всё вместе, серверу ресурсов нужно всего несколько строк — валидация токенов напрямую привязана к опубликованным ключам эмитента, и нигде не настроен ни один секрет:
 
-```rust
+```rust compile
 use volga::{App, auth::{AuthClaims, roles}, ok};
 use serde::Deserialize;
 

--- a/docs/ru/security-access/oauth.md
+++ b/docs/ru/security-access/oauth.md
@@ -158,6 +158,21 @@ app.use_oauth_server_metadata()  // GET /.well-known/oauth-authorization-server
 Замыкание для метаданных сервера предзаполняется значениями OAuth 2.1: `response_types_supported = ["code"]` и `grant_types_supported = ["authorization_code"]`. OIDC-специфичные поля, обязательные для совместимого документа провайдера (`subject_types_supported`, `id_token_signing_alg_values_supported`, `userinfo_endpoint`, …), можно задать через [`with_additional_field(...)`](https://docs.rs/volga/latest/volga/auth/oauth/struct.AuthorizationServerMetadata.html#method.with_additional_field).
 :::
 
+Два поля, которые стоит назвать отдельно, стали типизированными построителями в **v0.9.6** и **v0.9.8**:
+
+```rust
+let mut app = App::new()
+    .with_oauth_server_metadata(|metadata| metadata
+        .with_issuer("https://auth.example.com")
+        // RFC 9207: параметр `iss` возвращается в ответах авторизации,
+        // что позволяет клиентам обнаружить подмену сервера авторизации
+        .with_authorization_response_iss_parameter(true)
+        // RFC 9449: алгоритмы, принимаемые в доказательствах DPoP
+        .with_dpop_signing_algs(["ES256"]));
+```
+
+Объявление поддержки RFC 9207 делает её **обязательной** для клиентов: [валидация callback](/volga-docs/ru/security-access/oauth-client.html#валидация-callback) в `volga-oauth-client` после этого отклонит ответ без `iss`. Метод `with_authorization_response_iss_parameter` также принимается в секции `[oauth.server]` файла конфигурации. Клиентская половина второго описана в разделе [DPoP](/volga-docs/ru/security-access/dpop.html); на стороне ресурса поле `dpop_signing_alg_values_supported` доступно у [`ProtectedResourceMetadata`](https://docs.rs/volga/latest/volga/auth/oauth/struct.ProtectedResourceMetadata.html) под тем же именем.
+
 Оба документа также могут приходить из секций `[oauth.resource]` / `[oauth.server]` файла конфигурации (feature `config`); файл переопределяет предыдущие вызовы построителя. Сокращение `set_*` настраивает минимальный документ только по идентификатору:
 
 ```rust


### PR DESCRIPTION
The site was last updated on 2026-07-15, against 0.9.5. Three releases have landed since (0.9.6, 0.9.7, 0.9.8), and parts of 0.9.3 and 0.9.4 had never been documented at all. This brings both locales up to 0.9.8 and adds a CI check so the next drift is caught by a workflow rather than by a reader.

## Documentation

**New pages** (en + ru):

| Page | Covers |
|---|---|
| Raw Request Body | the `HttpBody` extractor (0.9.4), pass-through responses, streaming via `HttpBodyStream`, the body constructors |
| Graceful Shutdown | `ShutdownHandle`, `App::with_shutdown`, `with_shutdown_signal`, `shutdown_on` (0.9.3), and how this differs from per-request cancellation |
| Machine-to-Machine Grants | `client_credentials`, `jwt_bearer`, `exchange_token` (0.9.8), the store-backed `token(key)`, and what is refused before the network |
| DPoP | sender-constrained tokens (0.9.8): key lifetime, bound tokens, protecting resource requests, the nonce round, the DPoP challenge |

**Updated pages**:

* **Quick Start** — `bind()` now takes host names and IPv6 literals (0.9.7), with a warning about the silent `0.0.0.0` fallback that preceded it. Worth reading: a bind meant to stay on loopback used to listen on every interface, with no error and no log line.
* **HTTP** — the full set of verbs, the `QUERY` method via `map_query`, and the generic `map` (0.9.4). Retitled to *HTTP Versions and Methods* to match what it now covers.
* **OAuth 2.1 Client** — client authentication (`private_key_jwt`, publishing the public JWK), `validate_callback` and the RFC 9207 `iss` check (0.9.6), the registration fields that became typed, propagating a `ClientError` out of a handler with `?`.
* **OAuth 2.1 & OpenID Connect** — the `authorization_response_iss_parameter` and `dpop_signing_algs` metadata builders.
* **Authentication and Authorization** — `Algorithm` is now a re-export of `JwsAlgorithm`.

Four pre-existing broken links in the middleware pages are fixed along the way.

## CI

`ci/check-snippets.py` compiles the site's snippets against the published crates on every PR. It is adapted from the same check in `neva-docs`; the marker lives in the fence's info string, which VuePress ignores and does not render:

    ```rust compile
    ```rust compile-fragment
    ```rust compile features="full jwt-derive"

Only marked blocks are checked — plenty of snippets lean on illustrative helpers that do not exist, and stubbing those generically would cost more than it catches. 221 of the 344 `rust` fences are self-contained enough to compile today and are marked; the other 123 stay plain. Both locales are scanned, so a translation whose code drifted from the English is caught too.

Two things differ from the `neva-docs` version:

* the build runs with `--keep-going` and reads the JSON diagnostics, so a failing run reports every broken snippet by `file:line` rather than naming the crate that failed;
* `compile-fragment` wraps a block in an async fn that opens with `let mut app = App::new();` and injects `use volga::*;` — the shape the partial snippets here are written in.

`ci/README.md` documents the markers for contributors.

## Review notes

* The second commit is markers only: 221 insertions, 221 deletions, no prose touched. Review the first commit for content and the second for the checker.
* Verified locally: `npm run docs:build` renders 74 pages with the markers invisible in the output; `python3 ci/check-snippets.py` reports all 221 snippets compiling against `volga 0.9.8` from crates.io (~35s cold); a deliberately broken snippet exits 1 naming `file:line`; a link/anchor sweep over both locales reports 0 broken internal links.
* The new pages are in the sidebar for both locales, and heading structure is in parity between `en` and `ru`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)