### PR TITLE
ci: name snippet bins by path, so two pages can't silently share one check

### DIFF
--- a/ci/check-snippets.py
+++ b/ci/check-snippets.py
@@ -135,10 +135,14 @@ def collect(
             if mode is None or mode == "skip":
                 continue
             line = text.count("\n", 0, m.start()) + 1
-            locale = md.relative_to(docs_dir).parts[0]
+            # the whole relative path, not just the stem: two pages sharing a
+            # file name in different sections would otherwise write the same
+            # bin and one of them would go unchecked without a word
+            page = md.relative_to(docs_dir).with_suffix("").as_posix()
+            slug = re.sub(r"[^a-z0-9]+", "_", page.lower())
             snippets.append(
                 {
-                    "name": f"{locale}_{md.stem}_{idx}".replace("-", "_"),
+                    "name": f"{slug}_{idx}",
                     "origin": f"{md}:{line}",
                     "features": d_features
                     or features
@@ -180,6 +184,15 @@ def write_crate(crate: Path, features: str, group: list[dict]) -> None:
     for s in group:
         (crate / "src" / "bin" / f"{s['name']}.rs").write_text(
             f"// from {s['origin']}\n{s['source']}", encoding="utf-8"
+        )
+
+    # a snippet that never reached the crate is a snippet nobody checked, and
+    # a silent pass is worse than no check at all
+    written = len(list((crate / "src" / "bin").glob("*.rs")))
+    if written != len(group):
+        raise SystemExit(
+            f"internal error: {len(group)} snippet(s) collected but {written} "
+            f"file(s) written for features = {features}"
         )
 
 


### PR DESCRIPTION
A follow-up to #52 — this commit was pushed to that branch after it had already been squash-merged, so it never landed.

## The bug

`ci/check-snippets.py` named each scratch bin `locale_stem_idx`. Two pages sharing a file name in different sections of one locale therefore produce the *same* bin name, and the second write silently overwrites the first: one snippet gets checked twice, the other not at all, with nothing in the output to say so.

Reproduced against both versions on a two-page tree — `docs/en/getting-started/http.md` and `docs/en/protocols-realtime/http.md`:

```
main (before fix)      names=['en_http_0', 'en_http_0'] collisions=['en_http_0']
branch (after fix)     names=['en_getting_started_http_0', 'en_protocols_realtime_http_0'] collisions=none
```

Nothing in the tree collides today, which is exactly why it would have gone unnoticed until a page was added — `http.md`, `middleware.md`, `auth.md` are all plausible repeats across sections.

## The fix

* The bin name is the full relative path of the page, not just its stem.
* `write_crate` asserts that as many files were written as snippets were collected. A snippet that never reached the crate is a snippet nobody checked, and a silent pass is worse than no check at all — so this fails loudly rather than reporting a green run over a smaller set.

## Verification

* The collision reproduction above.
* `python3 ci/check-snippets.py` on this branch: `OK - all 221 snippet(s) compiled`, and the scratch crate holds 221 bin files for 221 collected snippets.
* Mutation check still behaves: breaking snippets in `en` and `ru` pages exits 1 and names each by `file:line`.

Docs are untouched; this is the checker only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)